### PR TITLE
Feat: make TF32 and cuDNN benchmarking opt-in

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -47,8 +47,9 @@ Options Overview
 - Input/Output: ``--in-spec``, ``--out-spec`` (TensorStore JSON specs)
 - Model: ``--model-type`` (registry key), ``--weights`` (optional path)
 - Geometry: ``--t``, ``--c``, ``--patch``, ``--overlap``, ``--block``, ``--batch``
-- Devices/Precision: ``--devices``, ``--no-amp``, ``--no-tf32``, ``--compile``,
-  ``--compile-mode``, ``--no-compile-dynamic``
+- Devices/Precision: ``--devices``, ``--no-amp``, ``--tf32``,
+  ``--cudnn-benchmark``, ``--compile``, ``--compile-mode``,
+  ``--no-compile-dynamic``
 - Queues: ``--max-inflight-batches``, ``--prep-workers``, ``--writer-workers``
 - Seam handling: ``--seam-mode {trim,blend}``, ``--trim-voxels``, ``--halo``,
   ``--min-blend-weight``
@@ -58,4 +59,3 @@ Options Overview
 
 See ``src/aind_torch_utils/run.py`` for authoritative CLI definitions and
 ``src/aind_torch_utils/config.py`` for detailed field descriptions.
-

--- a/src/aind_torch_utils/config.py
+++ b/src/aind_torch_utils/config.py
@@ -27,7 +27,10 @@ class InferenceConfig(BaseModel):
         description="List of torch devices to use",
     )
     amp: bool = Field(default=True, description="Use AMP")
-    use_tf32: bool = Field(default=True, description="Use TF32")
+    use_tf32: bool = Field(default=False, description="Use TF32")
+    cudnn_benchmark: bool = Field(
+        default=False, description="Enable cuDNN benchmarking"
+    )
     use_compile: bool = Field(default=False, description="Use torch.compile")
     compile_mode: str = Field(
         default="reduce-overhead",

--- a/src/aind_torch_utils/run.py
+++ b/src/aind_torch_utils/run.py
@@ -457,8 +457,11 @@ def _parse_args(argv: List[str]) -> argparse.Namespace:
         default=["cuda:0"],
     )
     ap.add_argument("--no-amp", action="store_true")
+    ap.add_argument("--tf32", action="store_true", help="Enable TF32")
     ap.add_argument(
-        "--no-tf32", action="store_true", help="Disable TF32 (enabled by default)"
+        "--cudnn-benchmark",
+        action="store_true",
+        help="Enable cuDNN benchmarking",
     )
     ap.add_argument("--compile", action="store_true", help="Enable torch.compile")
     ap.add_argument(
@@ -595,7 +598,8 @@ def main(argv: Optional[List[str]] = None) -> None:
         c_idx=args.c,
         devices=args.devices,
         amp=not args.no_amp,
-        use_tf32=not args.no_tf32,
+        use_tf32=args.tf32,
+        cudnn_benchmark=args.cudnn_benchmark,
         use_compile=args.compile,
         compile_mode=args.compile_mode,
         compile_dynamic=not args.no_compile_dynamic,

--- a/src/aind_torch_utils/workers.py
+++ b/src/aind_torch_utils/workers.py
@@ -341,10 +341,8 @@ class GpuWorker:
         self.write_queues = write_queues
         self.num_writers = len(write_queues)
 
-        if self.cfg.use_tf32:
-            torch.backends.cuda.matmul.allow_tf32 = True
-            torch.backends.cudnn.allow_tf32 = True
-        torch.backends.cudnn.benchmark = True
+        torch.backends.cuda.matmul.allow_tf32 = self.cfg.use_tf32
+        torch.backends.cudnn.benchmark = self.cfg.cudnn_benchmark
 
         self.model.to(self.device)
         self.model.eval()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+import pytest
+
+from aind_torch_utils.config import InferenceConfig
+
+
+def test_precision_performance_defaults_to_false():
+    cfg = InferenceConfig(
+        patch=(16, 16, 16),
+        overlap=4,
+        trim_voxels=2,
+        block=(32, 32, 32),
+    )
+
+    assert cfg.use_tf32 is False
+    assert cfg.cudnn_benchmark is False
+
+
+@pytest.mark.parametrize("field", ["use_tf32", "cudnn_benchmark"])
+def test_precision_performance_config_overrides(field):
+    cfg = InferenceConfig(
+        patch=(16, 16, 16),
+        overlap=4,
+        trim_voxels=2,
+        block=(32, 32, 32),
+        **{field: True},
+    )
+
+    assert getattr(cfg, field) is True


### PR DESCRIPTION
This PR updates CUDA backend configuration so performance-oriented PyTorch backend flags are controlled explicitly by `InferenceConfig` and default to `False`.

Previously, `GpuWorker` always enabled `torch.backends.cudnn.benchmark`, and `use_tf32=True` also forced both matmul TF32 and cuDNN TF32 on. This made backend behavior less explicit and could override PyTorch/session defaults. The new behavior sets only the intended backend options directly from config:

```python
torch.backends.cuda.matmul.allow_tf32 = self.cfg.use_tf32
torch.backends.cudnn.benchmark = self.cfg.cudnn_benchmark
```

**Changes**

- Changed `InferenceConfig.use_tf32` default from `True` to `False`
- Added `InferenceConfig.cudnn_benchmark`, defaulting to `False`
- Stopped modifying `torch.backends.cudnn.allow_tf32`, which defaults to `True` in PyTorch. This can be set to `False` by the user in their inference script if desired.
- Replaced CLI opt-out flag `--no-tf32` with opt-in `--tf32`
- Added opt-in CLI flag `--cudnn-benchmark`
- Updated CLI docs to reflect the new flags
- Added config tests covering the new defaults and override behavior

**Rationale**

TF32 matmul and cuDNN benchmarking can improve throughput in certain cases, but it is hardware and data-size dependent. TF32 is only supported for Ampere and newer GPUs, whereas the default CodeOcean flex instance uses an older T4 (Turing). cuDNN benchmarking can also introduce a performance hit for smaller volumes where the auto-tuner overhead eclipses any performance gain.