### PR TITLE
Refactor architecture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ skip = [".conda"]
 
 [tool.interrogate]
 exclude = ["setup.py", "docs", "build", ".conda"]
-fail-under = 0
+fail-under = 100
 
 [tool.flake8]
 max-line-length = 88

--- a/src/aind_torch_utils/__init__.py
+++ b/src/aind_torch_utils/__init__.py
@@ -1,1 +1,3 @@
+"""Utilities for queue-based, multi-GPU PyTorch inference."""
+
 __version__ = "0.0.9"

--- a/src/aind_torch_utils/accumulators.py
+++ b/src/aind_torch_utils/accumulators.py
@@ -7,12 +7,11 @@ strategy is a first-class, injectable choice (issue #25 §3.3), supplied as a
 **factory** because one accumulator is created per block per output.
 
 All accumulators expose the same tiny contract (:class:`BlockAccumulator`): ``add`` a
-patch, then ``finalize`` to the **expanded** (core + halo) block; ``count``/``total``
-let the writer detect block completion.
+patch, then ``finalize`` to the **expanded** (core + halo) block. Block completion is
+tracked by the writer itself, so accumulators only merge.
 """
 from typing import (
     TYPE_CHECKING,
-    Any,
     Dict,
     Optional,
     Protocol,
@@ -29,9 +28,6 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 @runtime_checkable
 class BlockAccumulator(Protocol):
     """Merges patches for one block/output. Created once per block per output."""
-
-    total: int
-    count: int
 
     def add(
         self,
@@ -95,8 +91,6 @@ class WeightedAverageAccumulator:
         self.acc = np.zeros(block_shape, dtype=np.float32)
         self.wacc = np.zeros(block_shape, dtype=np.float32)
         self.eps = eps
-        self.count = 0
-        self.total = 0
         self.overlap = overlap
         self.seam_mode = seam_mode
         self.trim_voxels = (
@@ -226,8 +220,6 @@ class WeightedAverageAccumulator:
             self.acc[sz : sz + dz, sy : sy + dy, sx : sx + dx] += pp[:dz, :dy, :dx] * W
             self.wacc[sz : sz + dz, sy : sy + dy, sx : sx + dx] += W
 
-        self.count += 1
-
     def finalize(self) -> np.ndarray:
         out = self.acc / np.maximum(self.wacc, self.eps)
         return out
@@ -239,8 +231,6 @@ class _RegionAccumulator:
     def __init__(self, block_shape: Tuple[int, int, int], fill: float = 0.0):
         self.block_shape = block_shape
         self.acc = np.full(block_shape, fill, dtype=np.float32)
-        self.count = 0
-        self.total = 0
 
     def _region(self, start, valid):
         sz, sy, sx = start
@@ -264,7 +254,6 @@ class LastWriteAccumulator(_RegionAccumulator):
     def add(self, pred_patch, start, valid):
         block_sl, patch_sl = self._region(start, valid)
         self.acc[block_sl] = np.asarray(pred_patch[patch_sl], dtype=np.float32)
-        self.count += 1
 
 
 class MaxAccumulator(_RegionAccumulator):
@@ -283,7 +272,6 @@ class MaxAccumulator(_RegionAccumulator):
         np.maximum(
             region, np.asarray(pred_patch[patch_sl], dtype=np.float32), out=region
         )
-        self.count += 1
 
     def finalize(self) -> np.ndarray:
         self.acc[np.isneginf(self.acc)] = 0.0
@@ -296,7 +284,6 @@ class SumAccumulator(_RegionAccumulator):
     def add(self, pred_patch, start, valid):
         block_sl, patch_sl = self._region(start, valid)
         self.acc[block_sl] += np.asarray(pred_patch[patch_sl], dtype=np.float32)
-        self.count += 1
 
 
 class MajorityVoteAccumulator:
@@ -304,14 +291,18 @@ class MajorityVoteAccumulator:
 
     Averaging discrete labels is meaningless; this counts votes per label and
     finalizes to the most-voted label (ties broken toward the smaller label).
-    Memory scales with the number of distinct labels seen in the block.
+    Voxels that receive no votes finalize to 0 (background), matching
+    :class:`MaxAccumulator`. Memory scales with the number of distinct labels
+    seen in the block.
+
+    Labels are matched by exact float value: the runtime carries predictions as
+    float16/float32, so integer instance IDs survive only up to 2**24 in float32
+    (2048 in float16 under AMP) — keep label ranges within those bounds.
     """
 
     def __init__(self, block_shape: Tuple[int, int, int]):
         self.block_shape = block_shape
-        self.votes: Dict[Any, np.ndarray] = {}
-        self.count = 0
-        self.total = 0
+        self.votes: Dict[float, np.ndarray] = {}
 
     def add(self, pred_patch, start, valid):
         sz, sy, sx = start
@@ -319,20 +310,28 @@ class MajorityVoteAccumulator:
         patch = np.asarray(pred_patch[:dz, :dy, :dx])
         region = (slice(sz, sz + dz), slice(sy, sy + dy), slice(sx, sx + dx))
         for label in np.unique(patch):
-            arr = self.votes.get(label)
+            if np.isnan(label):
+                # NaN is not a label: NaN != NaN would miss the dict lookup
+                # and allocate a fresh block-sized vote plane on every add,
+                # and `patch == NaN` is all-False so it can never win a vote.
+                continue
+            key = float(label)
+            arr = self.votes.get(key)
             if arr is None:
                 arr = np.zeros(self.block_shape, dtype=np.float32)
-                self.votes[label] = arr
+                self.votes[key] = arr
             arr[region] += patch == label
-        self.count += 1
 
     def finalize(self) -> np.ndarray:
         if not self.votes:
             return np.zeros(self.block_shape, dtype=np.float32)
         labels = sorted(self.votes.keys())
         stack = np.stack([self.votes[label] for label in labels], axis=0)
-        winner = np.asarray(labels)[np.argmax(stack, axis=0)]
-        return winner.astype(np.float32)
+        winner = np.asarray(labels, dtype=np.float32)[np.argmax(stack, axis=0)]
+        # argmax over an all-zero column returns index 0, which would hand
+        # zero-vote voxels the smallest label seen in the block; force them
+        # to background instead.
+        return np.where(stack.max(axis=0) > 0, winner, np.float32(0.0))
 
 
 def weighted_average_factory(

--- a/src/aind_torch_utils/accumulators.py
+++ b/src/aind_torch_utils/accumulators.py
@@ -1,11 +1,67 @@
-from typing import Optional, Tuple
+"""Block accumulators: how overlapping patches merge into one block.
+
+The correct merge depends on what the output *means*. Averaging is right for
+continuous intensities but wrong for masks/labels: a binary mask averaged at a seam
+yields 0.5, which floors to 0 (an eroded mask at every patch boundary). So the merge
+strategy is a first-class, injectable choice (issue #25 §3.3), supplied as a
+**factory** because one accumulator is created per block per output.
+
+All accumulators expose the same tiny contract (:class:`BlockAccumulator`): ``add`` a
+patch, then ``finalize`` to the **expanded** (core + halo) block; ``count``/``total``
+let the writer detect block completion.
+"""
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Optional,
+    Protocol,
+    Tuple,
+    runtime_checkable,
+)
 
 import numpy as np
 
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from aind_torch_utils.context import BlockContext
 
-class BlockAccumulator:
-    """
-    Accumulates predicted patches into a single block, handling seams.
+
+@runtime_checkable
+class BlockAccumulator(Protocol):
+    """Merges patches for one block/output. Created once per block per output."""
+
+    total: int
+    count: int
+
+    def add(
+        self,
+        pred_patch: np.ndarray,
+        start: Tuple[int, int, int],
+        valid: Tuple[int, int, int],
+    ) -> None:
+        """Merge one patch at ``start`` with ``valid`` (dz, dy, dx) extent."""
+        ...
+
+    def finalize(self) -> np.ndarray:
+        """Return the merged **expanded** (core + halo) block."""
+        ...
+
+
+class BlockAccumulatorFactory(Protocol):
+    """Builds a fresh :class:`BlockAccumulator` for a block of ``shape``."""
+
+    def __call__(
+        self, shape: Tuple[int, int, int], ctx: "BlockContext"
+    ) -> BlockAccumulator:
+        """Create an accumulator sized to the expanded block ``shape``."""
+        ...
+
+
+class WeightedAverageAccumulator:
+    """Accumulates predicted patches into a single block, handling seams.
+
+    This is the historical default merge: ``trim`` (last-write on cropped margins)
+    or ``blend`` (edge-aware weighted average). Correct for continuous intensities.
     """
 
     def __init__(
@@ -175,3 +231,133 @@ class BlockAccumulator:
     def finalize(self) -> np.ndarray:
         out = self.acc / np.maximum(self.wacc, self.eps)
         return out
+
+
+class _RegionAccumulator:
+    """Shared plumbing for accumulators that write into a single block buffer."""
+
+    def __init__(self, block_shape: Tuple[int, int, int], fill: float = 0.0):
+        self.block_shape = block_shape
+        self.acc = np.full(block_shape, fill, dtype=np.float32)
+        self.count = 0
+        self.total = 0
+
+    def _region(self, start, valid):
+        sz, sy, sx = start
+        dz, dy, dx = valid
+        return (
+            (slice(sz, sz + dz), slice(sy, sy + dy), slice(sx, sx + dx)),
+            (slice(0, dz), slice(0, dy), slice(0, dx)),
+        )
+
+    def finalize(self) -> np.ndarray:
+        return self.acc
+
+
+class LastWriteAccumulator(_RegionAccumulator):
+    """Overwrite each patch's full region; the last patch to cover a voxel wins.
+
+    Unlike ``trim``, no margins are cropped -- useful when patches are already
+    disjoint or a deterministic write order is acceptable.
+    """
+
+    def add(self, pred_patch, start, valid):
+        block_sl, patch_sl = self._region(start, valid)
+        self.acc[block_sl] = np.asarray(pred_patch[patch_sl], dtype=np.float32)
+        self.count += 1
+
+
+class MaxAccumulator(_RegionAccumulator):
+    """Element-wise maximum across overlapping patches (order-independent).
+
+    Good for foreground masks/logits: any patch that calls a voxel foreground wins.
+    Voxels no patch ever covers finalize to 0.
+    """
+
+    def __init__(self, block_shape: Tuple[int, int, int]):
+        super().__init__(block_shape, fill=-np.inf)
+
+    def add(self, pred_patch, start, valid):
+        block_sl, patch_sl = self._region(start, valid)
+        region = self.acc[block_sl]
+        np.maximum(
+            region, np.asarray(pred_patch[patch_sl], dtype=np.float32), out=region
+        )
+        self.count += 1
+
+    def finalize(self) -> np.ndarray:
+        self.acc[np.isneginf(self.acc)] = 0.0
+        return self.acc
+
+
+class SumAccumulator(_RegionAccumulator):
+    """Sum overlapping contributions (e.g. vote counts, densities)."""
+
+    def add(self, pred_patch, start, valid):
+        block_sl, patch_sl = self._region(start, valid)
+        self.acc[block_sl] += np.asarray(pred_patch[patch_sl], dtype=np.float32)
+        self.count += 1
+
+
+class MajorityVoteAccumulator:
+    """Per-voxel majority vote across overlapping patches (labels / instance IDs).
+
+    Averaging discrete labels is meaningless; this counts votes per label and
+    finalizes to the most-voted label (ties broken toward the smaller label).
+    Memory scales with the number of distinct labels seen in the block.
+    """
+
+    def __init__(self, block_shape: Tuple[int, int, int]):
+        self.block_shape = block_shape
+        self.votes: Dict[Any, np.ndarray] = {}
+        self.count = 0
+        self.total = 0
+
+    def add(self, pred_patch, start, valid):
+        sz, sy, sx = start
+        dz, dy, dx = valid
+        patch = np.asarray(pred_patch[:dz, :dy, :dx])
+        region = (slice(sz, sz + dz), slice(sy, sy + dy), slice(sx, sx + dx))
+        for label in np.unique(patch):
+            arr = self.votes.get(label)
+            if arr is None:
+                arr = np.zeros(self.block_shape, dtype=np.float32)
+                self.votes[label] = arr
+            arr[region] += patch == label
+        self.count += 1
+
+    def finalize(self) -> np.ndarray:
+        if not self.votes:
+            return np.zeros(self.block_shape, dtype=np.float32)
+        labels = sorted(self.votes.keys())
+        stack = np.stack([self.votes[label] for label in labels], axis=0)
+        winner = np.asarray(labels)[np.argmax(stack, axis=0)]
+        return winner.astype(np.float32)
+
+
+def weighted_average_factory(
+    eps: float,
+    overlap: int,
+    seam_mode: str,
+    trim_voxels: Optional[int],
+    min_blend_weight: float,
+) -> BlockAccumulatorFactory:
+    """Return the default factory: a :class:`WeightedAverageAccumulator` per block.
+
+    Reproduces the historical trim/blend merge from the runtime config, so a run
+    that does not inject a factory behaves exactly as before.
+    """
+
+    def factory(
+        shape: Tuple[int, int, int], ctx: "BlockContext"
+    ) -> BlockAccumulator:
+        return WeightedAverageAccumulator(
+            shape,
+            eps,
+            overlap=overlap,
+            seam_mode=seam_mode,
+            trim_voxels=trim_voxels,
+            min_blend_weight=min_blend_weight,
+        )
+
+    return factory

--- a/src/aind_torch_utils/accumulators.py
+++ b/src/aind_torch_utils/accumulators.py
@@ -124,6 +124,22 @@ class WeightedAverageAccumulator:
         o = self.overlap
 
         def _axis_weights(L_block, s, v):
+            """Build overlap-aware weights for one patch axis.
+
+            Parameters
+            ----------
+            L_block : int
+                Length of the block axis.
+            s : int
+                Patch start along the axis.
+            v : int
+                Valid patch length along the axis.
+
+            Returns
+            -------
+            np.ndarray
+                One-dimensional float32 blending weights.
+            """
             w = np.ones(v, dtype=np.float32)
             # left overlap exists if s > 0
             left = min(o, s)
@@ -221,6 +237,13 @@ class WeightedAverageAccumulator:
             self.wacc[sz : sz + dz, sy : sy + dy, sx : sx + dx] += W
 
     def finalize(self) -> np.ndarray:
+        """Return the weighted-average block.
+
+        Returns
+        -------
+        np.ndarray
+            The merged block as a float32 array.
+        """
         out = self.acc / np.maximum(self.wacc, self.eps)
         return out
 
@@ -229,10 +252,35 @@ class _RegionAccumulator:
     """Shared plumbing for accumulators that write into a single block buffer."""
 
     def __init__(self, block_shape: Tuple[int, int, int], fill: float = 0.0):
+        """Initialize the block buffer.
+
+        Parameters
+        ----------
+        block_shape : tuple of int
+            Shape of the output block in ``(z, y, x)`` order.
+        fill : float, optional
+            Initial value for every voxel.
+        """
         self.block_shape = block_shape
         self.acc = np.full(block_shape, fill, dtype=np.float32)
 
     def _region(self, start, valid):
+        """Build matching block and patch slices.
+
+        Parameters
+        ----------
+        start : tuple of int
+            Starting ``(z, y, x)`` coordinates within the block.
+        valid : tuple of int
+            Valid ``(dz, dy, dx)`` extent of the patch.
+
+        Returns
+        -------
+        block_slices : tuple of slice
+            Destination slices within the block.
+        patch_slices : tuple of slice
+            Source slices within the patch.
+        """
         sz, sy, sx = start
         dz, dy, dx = valid
         return (
@@ -241,6 +289,13 @@ class _RegionAccumulator:
         )
 
     def finalize(self) -> np.ndarray:
+        """Return the accumulated block.
+
+        Returns
+        -------
+        np.ndarray
+            The block buffer.
+        """
         return self.acc
 
 
@@ -252,6 +307,17 @@ class LastWriteAccumulator(_RegionAccumulator):
     """
 
     def add(self, pred_patch, start, valid):
+        """Overwrite a valid block region with values from a patch.
+
+        Parameters
+        ----------
+        pred_patch : np.ndarray
+            Patch values to write.
+        start : tuple of int
+            Starting ``(z, y, x)`` coordinates within the block.
+        valid : tuple of int
+            Valid ``(dz, dy, dx)`` extent of the patch.
+        """
         block_sl, patch_sl = self._region(start, valid)
         self.acc[block_sl] = np.asarray(pred_patch[patch_sl], dtype=np.float32)
 
@@ -264,9 +330,27 @@ class MaxAccumulator(_RegionAccumulator):
     """
 
     def __init__(self, block_shape: Tuple[int, int, int]):
+        """Initialize an empty accumulator.
+
+        Parameters
+        ----------
+        block_shape : tuple of int
+            Shape of the output block in ``(z, y, x)`` order.
+        """
         super().__init__(block_shape, fill=-np.inf)
 
     def add(self, pred_patch, start, valid):
+        """Merge a patch using the element-wise maximum.
+
+        Parameters
+        ----------
+        pred_patch : np.ndarray
+            Patch values to merge.
+        start : tuple of int
+            Starting ``(z, y, x)`` coordinates within the block.
+        valid : tuple of int
+            Valid ``(dz, dy, dx)`` extent of the patch.
+        """
         block_sl, patch_sl = self._region(start, valid)
         region = self.acc[block_sl]
         np.maximum(
@@ -274,6 +358,13 @@ class MaxAccumulator(_RegionAccumulator):
         )
 
     def finalize(self) -> np.ndarray:
+        """Return the maximum-merged block.
+
+        Returns
+        -------
+        np.ndarray
+            The merged block with uncovered values replaced by zero.
+        """
         self.acc[np.isneginf(self.acc)] = 0.0
         return self.acc
 
@@ -282,6 +373,17 @@ class SumAccumulator(_RegionAccumulator):
     """Sum overlapping contributions (e.g. vote counts, densities)."""
 
     def add(self, pred_patch, start, valid):
+        """Add a patch's values to a valid block region.
+
+        Parameters
+        ----------
+        pred_patch : np.ndarray
+            Patch values to add.
+        start : tuple of int
+            Starting ``(z, y, x)`` coordinates within the block.
+        valid : tuple of int
+            Valid ``(dz, dy, dx)`` extent of the patch.
+        """
         block_sl, patch_sl = self._region(start, valid)
         self.acc[block_sl] += np.asarray(pred_patch[patch_sl], dtype=np.float32)
 
@@ -301,10 +403,28 @@ class MajorityVoteAccumulator:
     """
 
     def __init__(self, block_shape: Tuple[int, int, int]):
+        """Initialize vote storage.
+
+        Parameters
+        ----------
+        block_shape : tuple of int
+            Shape of the output block in ``(z, y, x)`` order.
+        """
         self.block_shape = block_shape
         self.votes: Dict[float, np.ndarray] = {}
 
     def add(self, pred_patch, start, valid):
+        """Count each patch label as one vote.
+
+        Parameters
+        ----------
+        pred_patch : np.ndarray
+            Patch of discrete label values.
+        start : tuple of int
+            Starting ``(z, y, x)`` coordinates within the block.
+        valid : tuple of int
+            Valid ``(dz, dy, dx)`` extent of the patch.
+        """
         sz, sy, sx = start
         dz, dy, dx = valid
         patch = np.asarray(pred_patch[:dz, :dy, :dx])
@@ -323,6 +443,13 @@ class MajorityVoteAccumulator:
             arr[region] += patch == label
 
     def finalize(self) -> np.ndarray:
+        """Return the winning label for each voxel.
+
+        Returns
+        -------
+        np.ndarray
+            The majority-vote block, with zero for uncovered voxels.
+        """
         if not self.votes:
             return np.zeros(self.block_shape, dtype=np.float32)
         labels = sorted(self.votes.keys())
@@ -350,6 +477,20 @@ def weighted_average_factory(
     def factory(
         shape: Tuple[int, int, int], ctx: "BlockContext"
     ) -> BlockAccumulator:
+        """Create a configured weighted-average accumulator.
+
+        Parameters
+        ----------
+        shape : tuple of int
+            Shape of the expanded block in ``(z, y, x)`` order.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        BlockAccumulator
+            A new accumulator for the block.
+        """
         return WeightedAverageAccumulator(
             shape,
             eps,

--- a/src/aind_torch_utils/config.py
+++ b/src/aind_torch_utils/config.py
@@ -1,3 +1,5 @@
+"""Configuration models for tiled inference workflows."""
+
 import warnings
 from typing import List, Literal, Optional, Tuple, Union
 
@@ -13,6 +15,12 @@ CompileMode = Literal[
 
 
 class InferenceConfig(BaseModel):
+    """Configuration for block-wise, tiled inference.
+
+    The model validates geometry, seam handling, normalization, device, and
+    concurrency options together so invalid combinations fail before a run starts.
+    """
+
     # Geometry
     patch: Tuple[int, int, int] = Field(
         default=(64, 64, 64),

--- a/src/aind_torch_utils/context.py
+++ b/src/aind_torch_utils/context.py
@@ -1,9 +1,9 @@
 """Per-block context passed to injected pre/post-processing hooks.
 
-A :class:`BlockContext` describes *where* a block lives in the full volume. It is the
-information an injected ``BlockPreprocessor`` / ``BlockPostProcessor`` needs but the
-runtime carriers (:class:`~aind_torch_utils.workers.Batch` /
-:class:`~aind_torch_utils.workers.Preds`) do not otherwise expose in one place.
+A :class:`BlockContext` describes *where* a block lives in the full volume. It is
+built once per block in the prep stage and carried on the runtime carriers
+(:class:`~aind_torch_utils.workers.Batch` / :class:`~aind_torch_utils.workers.Preds`)
+so every stage shares the same derivation.
 
 The **absolute** ``expanded_bbox`` is load-bearing: corrections that sample a coarse
 *global* field (flat-field background, adaptive local statistics) must index that
@@ -18,10 +18,7 @@ in torch / tensorstore.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
-
-if TYPE_CHECKING:  # pragma: no cover - typing only, avoids an import cycle
-    from aind_torch_utils.workers import Preds
+from typing import Tuple
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,42 +78,6 @@ class BlockContext:
             core_bbox=core_bbox,
             expanded_bbox=expanded_bbox,
             halo_left=halo_left,
-            full_shape=full_shape,
-            t_idx=t_idx,
-            c_idx=c_idx,
-        )
-
-    @classmethod
-    def from_preds(
-        cls,
-        preds: "Preds",
-        full_shape: Tuple[int, int, int],
-        t_idx: int,
-        c_idx: int,
-    ) -> "BlockContext":
-        """Reconstruct the context in the writer stage from a :class:`Preds`.
-
-        ``Preds`` carries the core bbox, the left-halo widths, and the expanded
-        ``acc_shape`` but not the expanded bbox itself; recover it as
-        ``expanded_start = core_start - halo_left`` and
-        ``expanded_stop = expanded_start + acc_shape``. ``full_shape`` is a
-        volume-level constant supplied by the caller (it does not ride on every
-        per-block carrier).
-        """
-        (zsl, ysl, xsl) = preds.block_bbox
-        lz, ly, lx = preds.halo_left
-        bz, by, bx = preds.acc_shape
-        z0e, y0e, x0e = zsl.start - lz, ysl.start - ly, xsl.start - lx
-        expanded_bbox = (
-            slice(z0e, z0e + bz),
-            slice(y0e, y0e + by),
-            slice(x0e, x0e + bx),
-        )
-        return cls(
-            block_idx=preds.block_idx,
-            core_bbox=preds.block_bbox,
-            expanded_bbox=expanded_bbox,
-            halo_left=preds.halo_left,
             full_shape=full_shape,
             t_idx=t_idx,
             c_idx=c_idx,

--- a/src/aind_torch_utils/context.py
+++ b/src/aind_torch_utils/context.py
@@ -1,0 +1,123 @@
+"""Per-block context passed to injected pre/post-processing hooks.
+
+A :class:`BlockContext` describes *where* a block lives in the full volume. It is the
+information an injected ``BlockPreprocessor`` / ``BlockPostProcessor`` needs but the
+runtime carriers (:class:`~aind_torch_utils.workers.Batch` /
+:class:`~aind_torch_utils.workers.Preds`) do not otherwise expose in one place.
+
+The **absolute** ``expanded_bbox`` is load-bearing: corrections that sample a coarse
+*global* field (flat-field background, adaptive local statistics) must index that
+field by absolute coordinate so two blocks that overlap via the halo agree exactly on
+shared voxels -> the correction is seam-free. Any hook that does this needs the
+absolute expanded bounding box, which is why it is a first-class field here.
+
+This module is intentionally dependency-light (dataclass + typing only) so it can be
+imported by the workers, the (future) transform objects, and unit tests without pulling
+in torch / tensorstore.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids an import cycle
+    from aind_torch_utils.workers import Preds
+
+
+@dataclass(frozen=True, slots=True)
+class BlockContext:
+    """Absolute placement of one processing block within the full volume.
+
+    Attributes
+    ----------
+    block_idx : tuple of int
+        Block grid index ``(iz, iy, ix)``.
+    core_bbox : tuple of slice
+        Absolute ``(z, y, x)`` slices of the block's *core* region (the part that
+        is written out).
+    expanded_bbox : tuple of slice
+        Absolute ``(z, y, x)`` slices of the block's *core + halo* region (the part
+        that is read and processed). Sampling global fields by these absolute
+        coordinates is what keeps halo-overlapping blocks seam-free.
+    halo_left : tuple of int
+        Halo width actually added on the ``-z, -y, -x`` sides (0 at volume borders).
+    full_shape : tuple of int
+        Full volume spatial shape ``(Z, Y, X)``.
+    t_idx, c_idx : int
+        Time / channel indices being processed.
+    """
+
+    block_idx: Tuple[int, int, int]
+    core_bbox: Tuple[slice, slice, slice]
+    expanded_bbox: Tuple[slice, slice, slice]
+    halo_left: Tuple[int, int, int]
+    full_shape: Tuple[int, int, int]
+    t_idx: int
+    c_idx: int
+
+    @classmethod
+    def from_block(
+        cls,
+        block_idx: Tuple[int, int, int],
+        core_bbox: Tuple[slice, slice, slice],
+        expanded_bbox: Tuple[slice, slice, slice],
+        full_shape: Tuple[int, int, int],
+        t_idx: int,
+        c_idx: int,
+    ) -> "BlockContext":
+        """Build a context from the prep stage, deriving ``halo_left``.
+
+        ``PrepWorker`` already computes both the core and expanded bounding boxes, so
+        the left-halo widths are just their per-axis start offsets.
+        """
+        (zsl, ysl, xsl), (ezsl, eysl, exsl) = core_bbox, expanded_bbox
+        halo_left = (
+            zsl.start - ezsl.start,
+            ysl.start - eysl.start,
+            xsl.start - exsl.start,
+        )
+        return cls(
+            block_idx=block_idx,
+            core_bbox=core_bbox,
+            expanded_bbox=expanded_bbox,
+            halo_left=halo_left,
+            full_shape=full_shape,
+            t_idx=t_idx,
+            c_idx=c_idx,
+        )
+
+    @classmethod
+    def from_preds(
+        cls,
+        preds: "Preds",
+        full_shape: Tuple[int, int, int],
+        t_idx: int,
+        c_idx: int,
+    ) -> "BlockContext":
+        """Reconstruct the context in the writer stage from a :class:`Preds`.
+
+        ``Preds`` carries the core bbox, the left-halo widths, and the expanded
+        ``acc_shape`` but not the expanded bbox itself; recover it as
+        ``expanded_start = core_start - halo_left`` and
+        ``expanded_stop = expanded_start + acc_shape``. ``full_shape`` is a
+        volume-level constant supplied by the caller (it does not ride on every
+        per-block carrier).
+        """
+        (zsl, ysl, xsl) = preds.block_bbox
+        lz, ly, lx = preds.halo_left
+        bz, by, bx = preds.acc_shape
+        z0e, y0e, x0e = zsl.start - lz, ysl.start - ly, xsl.start - lx
+        expanded_bbox = (
+            slice(z0e, z0e + bz),
+            slice(y0e, y0e + by),
+            slice(x0e, x0e + bx),
+        )
+        return cls(
+            block_idx=preds.block_idx,
+            core_bbox=preds.block_bbox,
+            expanded_bbox=expanded_bbox,
+            halo_left=preds.halo_left,
+            full_shape=full_shape,
+            t_idx=t_idx,
+            c_idx=c_idx,
+        )

--- a/src/aind_torch_utils/execution.py
+++ b/src/aind_torch_utils/execution.py
@@ -1,0 +1,69 @@
+"""Execution policy for the GPU processor stage.
+
+The processor (the ``nn.Module`` slot in :class:`~aind_torch_utils.workers.GpuWorker`)
+already lets a workflow run arbitrary tensor-in/tensor-out GPU code. What was still
+global was *how* it runs: AMP, ``torch.compile``, input dtype, memory format. Those are
+processor constraints, not runtime knobs, so they belong on an ``ExecutionPolicy``
+attached to the processor/workflow rather than on ``InferenceConfig`` (issue #25 §3.1).
+
+The default is synthesized from the legacy config fields, so a run that does not inject
+a policy behaves exactly as before (AMP on by default).
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass
+class ExecutionPolicy:
+    """How the GPU processor is executed.
+
+    Attributes
+    ----------
+    input_dtype : torch.dtype
+        Host dtype the prep stage allocates patches in (what the model receives).
+    autocast : bool
+        Wrap the forward in ``torch.autocast('cuda', float16)``.
+    inference_mode : bool
+        Wrap the forward in ``torch.inference_mode()``.
+    compile : bool
+        Compile the processor with ``torch.compile``.
+    compile_mode : str
+        ``torch.compile`` mode (e.g. "default", "reduce-overhead").
+    compile_dynamic : Optional[bool]
+        ``torch.compile`` dynamic-shapes setting (None = auto).
+    channels_last : bool
+        Run the processor in channels-last (3D) memory format.
+    """
+
+    input_dtype: torch.dtype = torch.float32
+    autocast: bool = False
+    inference_mode: bool = True
+    compile: bool = False
+    compile_mode: str = "default"
+    compile_dynamic: Optional[bool] = None
+    channels_last: bool = False
+
+    @classmethod
+    def from_config(
+        cls,
+        amp: bool,
+        use_compile: bool,
+        compile_mode: str,
+        compile_dynamic: Optional[bool],
+    ) -> "ExecutionPolicy":
+        """Synthesize the default policy from the legacy config fields.
+
+        AMP drives both autocast and the float16 host dtype, matching the old prep +
+        GpuWorker behavior exactly.
+        """
+        return cls(
+            input_dtype=torch.float16 if amp else torch.float32,
+            autocast=amp,
+            inference_mode=True,
+            compile=use_compile,
+            compile_mode=compile_mode,
+            compile_dynamic=compile_dynamic,
+            channels_last=False,
+        )

--- a/src/aind_torch_utils/execution.py
+++ b/src/aind_torch_utils/execution.py
@@ -14,6 +14,22 @@ from typing import Optional
 
 import torch
 
+# CUDA-graph-capturing compile modes fail under this pipeline's threaded GPU
+# workers: torch.compile captures the graph lazily on the second forward, which
+# runs on a worker thread while warmup ran on the main thread, aborting with
+# cudaErrorStreamCaptureInvalidated. InferenceConfig._validate applies the same
+# downgrade for config-synthesized policies; GpuWorker consults this map so
+# directly-injected policies get identical protection.
+CUDA_SAFE_COMPILE_MODES = {
+    "reduce-overhead": "default",
+    "max-autotune": "max-autotune-no-cudagraphs",
+}
+
+
+def cuda_safe_compile_mode(mode: str) -> str:
+    """Return ``mode``, downgraded if it would capture CUDA graphs."""
+    return CUDA_SAFE_COMPILE_MODES.get(mode, mode)
+
 
 @dataclass
 class ExecutionPolicy:

--- a/src/aind_torch_utils/model_registry.py
+++ b/src/aind_torch_utils/model_registry.py
@@ -1,3 +1,5 @@
+"""Registry for named PyTorch model loaders."""
+
 from typing import Callable, Dict, Optional
 
 from torch import nn
@@ -34,6 +36,18 @@ class ModelRegistry:
         """
 
         def decorator(func: Callable[[Optional[str]], nn.Module]) -> Callable:
+            """Store a model loader under the requested name.
+
+            Parameters
+            ----------
+            func : Callable
+                Model loader to register.
+
+            Returns
+            -------
+            Callable
+                The registered loader, unchanged.
+            """
             cls._registry[name] = func
             return func
 

--- a/src/aind_torch_utils/monitoring.py
+++ b/src/aind_torch_utils/monitoring.py
@@ -1,3 +1,5 @@
+"""Background monitors for pipeline queues and system resource usage."""
+
 import threading
 import time
 from dataclasses import dataclass

--- a/src/aind_torch_utils/outputs.py
+++ b/src/aind_torch_utils/outputs.py
@@ -1,0 +1,96 @@
+"""Per-output specification and output-domain post-processors.
+
+A multi-output model returns a stacked ``(B, N, Z, Y, X)`` tensor, and different
+outputs want different handling: a mask channel wants max-merge + threshold + uint8,
+while a distance-transform channel wants mean-merge + identity + float32. So merge,
+post-processing, inversion, and dtype are bound **per output** in an
+:class:`OutputSpec` (issue #25 §3.5), not fixed globally on the writer.
+
+A :class:`BlockPostProcessor` is an output-domain transform (threshold, argmax, label
+cleanup, morphology) run on the finalized *expanded* block -- doing it before the halo
+crop gives neighborhood ops their context, provided their radius is within the halo.
+"""
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
+
+import numpy as np
+
+from aind_torch_utils.accumulators import BlockAccumulatorFactory
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from aind_torch_utils.context import BlockContext
+
+
+@runtime_checkable
+class BlockPostProcessor(Protocol):
+    """Output-domain transform on the finalized (expanded) block."""
+
+    def __call__(self, block: np.ndarray, ctx: "BlockContext") -> np.ndarray:
+        """Return the post-processed block (same spatial shape)."""
+        ...
+
+
+@dataclass
+class OutputSpec:
+    """One model output channel: where it goes and how it is finalized.
+
+    Attributes
+    ----------
+    store : ts.TensorStore
+        Destination store. Its dtype drives the final cast (integer stores clip).
+    accumulator_factory : BlockAccumulatorFactory
+        How overlapping patches merge for *this* output.
+    postprocess : BlockPostProcessor, optional
+        Output-domain transform applied on the finalized expanded block.
+    invert : bool
+        Whether the shared input transform's inverse is applied to this output
+        (only some outputs live in input-intensity space).
+    """
+
+    store: Any
+    accumulator_factory: BlockAccumulatorFactory
+    postprocess: Optional[BlockPostProcessor] = None
+    invert: bool = False
+
+
+class Threshold:
+    """Threshold a block to two levels: ``block > thresh ? above : below``.
+
+    numpy-only; the default (``above=1, below=0``) yields a binary mask.
+    """
+
+    def __init__(self, thresh: float = 0.0, above: float = 1.0, below: float = 0.0):
+        self.thresh = float(thresh)
+        self.above = float(above)
+        self.below = float(below)
+
+    def __call__(self, block: np.ndarray, ctx: "BlockContext") -> np.ndarray:
+        return np.where(block > self.thresh, self.above, self.below).astype(
+            np.float32, copy=False
+        )
+
+
+class ThresholdThenOpen:
+    """Threshold to a binary mask, then binary-open it (removes speckle).
+
+    Morphology needs SciPy, which is not a core dependency, so it is imported
+    lazily and this class raises a clear error at construction if SciPy is absent.
+    Runs on the expanded block, so opening sees halo context (keep the structuring
+    radius within the halo to avoid re-introducing block-edge artifacts).
+    """
+
+    def __init__(self, thresh: float = 0.0, open_iters: int = 1):
+        try:
+            from scipy import ndimage
+        except ImportError as exc:  # pragma: no cover - depends on optional dep
+            raise ImportError(
+                "ThresholdThenOpen requires scipy; install scipy or use Threshold."
+            ) from exc
+        self._ndi = ndimage
+        self.thresh = float(thresh)
+        self.open_iters = int(open_iters)
+
+    def __call__(self, block: np.ndarray, ctx: "BlockContext") -> np.ndarray:
+        mask = block > self.thresh
+        opened = self._ndi.binary_opening(mask, iterations=self.open_iters)
+        return opened.astype(np.float32, copy=False)

--- a/src/aind_torch_utils/outputs.py
+++ b/src/aind_torch_utils/outputs.py
@@ -65,9 +65,11 @@ class Threshold:
         self.below = float(below)
 
     def __call__(self, block: np.ndarray, ctx: "BlockContext") -> np.ndarray:
-        return np.where(block > self.thresh, self.above, self.below).astype(
-            np.float32, copy=False
-        )
+        # float32 branch scalars keep np.where from promoting the whole block
+        # to float64 (Python-float branches would double the allocation).
+        return np.where(
+            block > self.thresh, np.float32(self.above), np.float32(self.below)
+        ).astype(np.float32, copy=False)
 
 
 class ThresholdThenOpen:

--- a/src/aind_torch_utils/outputs.py
+++ b/src/aind_torch_utils/outputs.py
@@ -60,11 +60,36 @@ class Threshold:
     """
 
     def __init__(self, thresh: float = 0.0, above: float = 1.0, below: float = 0.0):
+        """Initialize the threshold operation.
+
+        Parameters
+        ----------
+        thresh : float, optional
+            Exclusive lower bound for the ``above`` output value.
+        above : float, optional
+            Value emitted where the input exceeds ``thresh``.
+        below : float, optional
+            Value emitted where the input does not exceed ``thresh``.
+        """
         self.thresh = float(thresh)
         self.above = float(above)
         self.below = float(below)
 
     def __call__(self, block: np.ndarray, ctx: "BlockContext") -> np.ndarray:
+        """Threshold a block.
+
+        Parameters
+        ----------
+        block : np.ndarray
+            Finalized expanded block to threshold.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        np.ndarray
+            Float32 array containing the configured output levels.
+        """
         # float32 branch scalars keep np.where from promoting the whole block
         # to float64 (Python-float branches would double the allocation).
         return np.where(
@@ -82,6 +107,20 @@ class ThresholdThenOpen:
     """
 
     def __init__(self, thresh: float = 0.0, open_iters: int = 1):
+        """Initialize thresholding and binary opening.
+
+        Parameters
+        ----------
+        thresh : float, optional
+            Exclusive lower bound for foreground voxels.
+        open_iters : int, optional
+            Number of binary-opening iterations.
+
+        Raises
+        ------
+        ImportError
+            If the optional SciPy dependency is unavailable.
+        """
         try:
             from scipy import ndimage
         except ImportError as exc:  # pragma: no cover - depends on optional dep
@@ -93,6 +132,20 @@ class ThresholdThenOpen:
         self.open_iters = int(open_iters)
 
     def __call__(self, block: np.ndarray, ctx: "BlockContext") -> np.ndarray:
+        """Threshold and binary-open a block.
+
+        Parameters
+        ----------
+        block : np.ndarray
+            Finalized expanded block to process.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        np.ndarray
+            Binary-opened float32 mask.
+        """
         mask = block > self.thresh
         opened = self._ndi.binary_opening(mask, iterations=self.open_iters)
         return opened.astype(np.float32, copy=False)

--- a/src/aind_torch_utils/recipes/__init__.py
+++ b/src/aind_torch_utils/recipes/__init__.py
@@ -1,0 +1,12 @@
+"""Workflow recipes.
+
+Each module here owns one workflow's math: its processor, preprocessing/correction,
+per-output specs, and execution policy, registered via
+``@WorkflowRegistry.register(...)``. Importing this package registers the recipes it
+contains, mirroring how :mod:`aind_torch_utils.models` registers models on import.
+
+This is the home for workflow-specific code that must not live in the generic core
+(issue #25 §4.6/§4.7). It is currently empty: migrating a concrete specialized
+workflow (e.g. a cupy segmentation processor with its correction preprocessing) is
+PR7, which depends on that workflow's code landing on ``dev`` first.
+"""

--- a/src/aind_torch_utils/run.py
+++ b/src/aind_torch_utils/run.py
@@ -18,9 +18,11 @@ from typing import Any, List, Optional, Tuple, Union
 from torch import nn
 
 import aind_torch_utils.models  # This registers all models when imported
+from aind_torch_utils import transforms
 from aind_torch_utils.config import InferenceConfig
 from aind_torch_utils.model_registry import ModelRegistry
 from aind_torch_utils.monitoring import QueueMonitor, SystemMonitor
+from aind_torch_utils.transforms import BlockPreprocessor
 from aind_torch_utils.utils import open_ts_spec
 from aind_torch_utils.workers import GpuWorker, PrepWorker, WriterWorker
 
@@ -166,6 +168,8 @@ def _setup_workers(
     num_prep_workers: int,
     prep_q: queue.Queue,
     write_queues: List[queue.Queue],
+    preprocess: BlockPreprocessor,
+    full_shape: Tuple[int, int, int],
 ) -> Tuple[List[PrepWorker], List[GpuWorker], List[WriterWorker]]:
     """Sets up the workers for the pipeline.
 
@@ -185,6 +189,10 @@ def _setup_workers(
         The prep queue.
     write_queues : List[queue.Queue]
         A list of writer queues.
+    preprocess : BlockPreprocessor
+        The injected block transform shared by prep (forward) and writer (inverse).
+    full_shape : Tuple[int, int, int]
+        Full volume spatial shape ``(Z, Y, X)``.
 
     Returns
     -------
@@ -197,6 +205,7 @@ def _setup_workers(
             input_store,
             prep_q,
             cfg.patch,
+            preprocess,
             worker_id=i,
             num_workers=num_prep_workers,
         )
@@ -207,7 +216,7 @@ def _setup_workers(
         for device in cfg.devices
     ]
     writer_workers = [
-        WriterWorker(cfg, output_stores, write_queues[i])
+        WriterWorker(cfg, output_stores, write_queues[i], preprocess, full_shape)
         for i in range(len(write_queues))
     ]
     return prep_workers, gpu_workers, writer_workers
@@ -222,6 +231,8 @@ def _setup_worker_threads(
     num_prep_workers: int,
     prep_q: queue.Queue,
     write_queues: List[queue.Queue],
+    preprocess: BlockPreprocessor,
+    full_shape: Tuple[int, int, int],
 ) -> Tuple[List[threading.Thread], List[threading.Thread], List[threading.Thread]]:
     """Sets up the worker threads for the pipeline.
 
@@ -259,6 +270,8 @@ def _setup_worker_threads(
         num_prep_workers,
         prep_q,
         write_queues,
+        preprocess,
+        full_shape,
     )
 
     # Threads
@@ -287,6 +300,7 @@ def run(
     metrics_interval: float = 0.5,
     num_prep_workers: int = 1,
     num_writer_workers: int = 1,
+    preprocess: Optional[BlockPreprocessor] = None,
 ) -> None:
     """Runs the inference pipeline.
 
@@ -311,6 +325,11 @@ def run(
         The number of prep workers to use, by default 1.
     num_writer_workers : int, optional
         The number of writer workers to use, by default 1.
+    preprocess : Optional[BlockPreprocessor], optional
+        Injected input-domain transform applied per block (its inverse runs in
+        the writer). When ``None`` (default), one is synthesized from the legacy
+        config fields (``normalize``/``norm_lower``/``norm_upper``/``clip_norm``),
+        preserving existing behavior.
     """
     output_stores: List[Any] = (
         output_store if isinstance(output_store, list) else [output_store]
@@ -319,6 +338,17 @@ def run(
     # Validate shapes
     T, C, Z, Y, X = tuple(input_store.domain.shape)
     assert 0 <= cfg.t_idx < T and 0 <= cfg.c_idx < C, "Invalid t/c indices"
+
+    # Synthesize the default block transform from config when none is injected,
+    # so existing callers keep their current normalization behavior.
+    if preprocess is None:
+        preprocess = transforms.from_config(
+            cfg.normalize,
+            cfg.norm_lower,
+            cfg.norm_upper,
+            cfg.eps,
+            cfg.clip_norm,
+        )
 
     # Queues
     prep_q, write_queues = _setup_queues(
@@ -342,6 +372,8 @@ def run(
         num_prep_workers,
         prep_q,
         write_queues,
+        preprocess,
+        (Z, Y, X),
     )
     all_threads = prep_threads + gpu_threads + writer_threads
 

--- a/src/aind_torch_utils/run.py
+++ b/src/aind_torch_utils/run.py
@@ -488,10 +488,20 @@ def run(
         compile / channels_last). When ``None`` (default), synthesized from cfg
         (``amp``/``use_compile``/``compile_mode``/``compile_dynamic``), so AMP-on
         stays the legacy default.
+
+    Raises
+    ------
+    ValueError
+        If the configured time or channel index is outside the input store.
     """
     # Validate shapes
     T, C, Z, Y, X = tuple(input_store.domain.shape)
-    assert 0 <= cfg.t_idx < T and 0 <= cfg.c_idx < C, "Invalid t/c indices"
+    if not (0 <= cfg.t_idx < T and 0 <= cfg.c_idx < C):
+        raise ValueError(
+            "Invalid t/c indices: "
+            f"t_idx={cfg.t_idx} must be in [0, {T}) and "
+            f"c_idx={cfg.c_idx} must be in [0, {C})."
+        )
 
     # Synthesize the default block transform from config when none is injected,
     # so existing callers keep their current normalization behavior.

--- a/src/aind_torch_utils/run.py
+++ b/src/aind_torch_utils/run.py
@@ -18,6 +18,7 @@ from typing import Any, List, Optional, Tuple, Union
 from torch import nn
 
 import aind_torch_utils.models  # This registers all models when imported
+import aind_torch_utils.recipes  # This registers all workflow recipes when imported
 from aind_torch_utils import transforms
 from aind_torch_utils.accumulators import weighted_average_factory
 from aind_torch_utils.config import InferenceConfig
@@ -28,6 +29,7 @@ from aind_torch_utils.outputs import OutputSpec
 from aind_torch_utils.transforms import BlockPreprocessor
 from aind_torch_utils.utils import open_ts_spec
 from aind_torch_utils.workers import GpuWorker, PrepWorker, WriterWorker
+from aind_torch_utils.workflow import Workflow, WorkflowRegistry
 
 logging.basicConfig(
     level=logging.INFO,
@@ -520,6 +522,48 @@ def run(
     logger.info(f"Throughput: {throughput:.2f}MB/s")
 
 
+def run_workflow(
+    workflow: Workflow,
+    input_store: Any,
+    output_store: Union[Any, List[Any], None],
+    cfg: InferenceConfig,
+    **run_kwargs: Any,
+) -> None:
+    """Run a :class:`Workflow` by unpacking its injected objects into :func:`run`.
+
+    The workflow supplies the processor, preprocessing, per-output specs, and
+    execution policy; everything else (metrics, worker counts) is forwarded via
+    ``run_kwargs``.
+
+    Parameters
+    ----------
+    workflow : Workflow
+        The recipe to run.
+    input_store : Any
+        The input data store.
+    output_store : Any or list of Any or None
+        Output store(s). Ignored when the workflow supplies its own ``outputs``.
+    cfg : InferenceConfig
+        The runtime configuration.
+    **run_kwargs : Any
+        Forwarded to :func:`run` (e.g. ``metrics_json``, ``num_prep_workers``).
+    """
+    output_stores = (
+        output_store if isinstance(output_store, list) else [output_store]
+    )
+    outputs = workflow.resolve_outputs(output_stores)
+    run(
+        workflow.processor,
+        input_store,
+        None if outputs is not None else output_store,
+        cfg,
+        preprocess=workflow.preprocess,
+        outputs=outputs,
+        execution=workflow.execution,
+        **run_kwargs,
+    )
+
+
 def load_model(model_type: str, weights_path: Optional[str] = None) -> nn.Module:
     """Loads a model from the registry.
 
@@ -573,10 +617,25 @@ def _parse_args(argv: List[str]) -> argparse.Namespace:
     ap.add_argument(
         "--model-type",
         type=str,
-        required=True,
-        help="Type of model to use (must be registered)",
+        default=None,
+        help="Type of model to use (must be registered). Alternative to --workflow.",
     )
     ap.add_argument("--weights", type=str, help="Model weights path")
+    ap.add_argument(
+        "--workflow",
+        type=str,
+        default=None,
+        help=(
+            "Named workflow recipe to run (registered in aind_torch_utils.recipes). "
+            "Alternative to --model-type; brings its own preprocessing/outputs."
+        ),
+    )
+    ap.add_argument(
+        "--workflow-params",
+        type=str,
+        default=None,
+        help="Path to a JSON file of parameters passed to the workflow builder.",
+    )
     ap.add_argument("--t", type=int, default=0)
     ap.add_argument("--c", type=int, default=0)
     ap.add_argument("--patch", type=int, nargs=3, default=(64, 64, 64))
@@ -735,7 +794,8 @@ def main(argv: Optional[List[str]] = None) -> None:
     """
     args = _parse_args(sys.argv[1:] if argv is None else argv)
 
-    model = load_model(args.model_type, args.weights)
+    if bool(args.model_type) == bool(args.workflow):
+        raise SystemExit("Provide exactly one of --model-type or --workflow.")
 
     in_arr = open_ts_spec(args.in_spec)
     out_arr = [open_ts_spec(s) for s in args.out_spec]
@@ -774,16 +834,23 @@ def main(argv: Optional[List[str]] = None) -> None:
     )
     logger.info(f"Inference config:\n{cfg}")
 
-    run(
-        model,
-        in_arr,
-        out_arr,
-        cfg,
-        args.metrics_json,
-        args.metrics_interval,
+    run_kwargs = dict(
+        metrics_json=args.metrics_json,
+        metrics_interval=args.metrics_interval,
         num_prep_workers=max(1, args.prep_workers),
         num_writer_workers=max(1, args.writer_workers),
     )
+
+    if args.workflow:
+        params: dict = {}
+        if args.workflow_params:
+            with open(args.workflow_params) as f:
+                params = json.load(f)
+        workflow = WorkflowRegistry.build(args.workflow, params)
+        run_workflow(workflow, in_arr, out_arr, cfg, **run_kwargs)
+    else:
+        model = load_model(args.model_type, args.weights)
+        run(model, in_arr, out_arr, cfg, **run_kwargs)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/aind_torch_utils/run.py
+++ b/src/aind_torch_utils/run.py
@@ -256,6 +256,7 @@ def _guarded_worker(
     """
 
     def target() -> None:
+        """Run the worker and record any uncaught exception."""
         try:
             run_fn(stop_event)
         except Exception as exc:  # noqa: BLE001 - any worker death is fatal

--- a/src/aind_torch_utils/run.py
+++ b/src/aind_torch_utils/run.py
@@ -19,13 +19,11 @@ from torch import nn
 
 import aind_torch_utils.models  # This registers all models when imported
 from aind_torch_utils import transforms
-from aind_torch_utils.accumulators import (
-    BlockAccumulatorFactory,
-    weighted_average_factory,
-)
+from aind_torch_utils.accumulators import weighted_average_factory
 from aind_torch_utils.config import InferenceConfig
 from aind_torch_utils.model_registry import ModelRegistry
 from aind_torch_utils.monitoring import QueueMonitor, SystemMonitor
+from aind_torch_utils.outputs import OutputSpec
 from aind_torch_utils.transforms import BlockPreprocessor
 from aind_torch_utils.utils import open_ts_spec
 from aind_torch_utils.workers import GpuWorker, PrepWorker, WriterWorker
@@ -167,14 +165,13 @@ def _setup_monitors(
 def _setup_workers(
     model: nn.Module,
     input_store: Any,
-    output_stores: List[Any],
+    output_specs: List[OutputSpec],
     cfg: InferenceConfig,
     num_prep_workers: int,
     prep_q: queue.Queue,
     write_queues: List[queue.Queue],
     preprocess: BlockPreprocessor,
     full_shape: Tuple[int, int, int],
-    accumulator_factory: BlockAccumulatorFactory,
 ) -> Tuple[List[PrepWorker], List[GpuWorker], List[WriterWorker]]:
     """Sets up the workers for the pipeline.
 
@@ -184,8 +181,8 @@ def _setup_workers(
         The model to use for inference.
     input_store : Any
         The input data store.
-    output_stores : List[Any]
-        One output data store per model output channel.
+    output_specs : List[OutputSpec]
+        One spec per model output channel (store + merge + post + invert).
     cfg : InferenceConfig
         The inference configuration.
     num_prep_workers : int
@@ -198,8 +195,6 @@ def _setup_workers(
         The injected block transform shared by prep (forward) and writer (inverse).
     full_shape : Tuple[int, int, int]
         Full volume spatial shape ``(Z, Y, X)``.
-    accumulator_factory : BlockAccumulatorFactory
-        Builds the per-block merge accumulators in each writer.
 
     Returns
     -------
@@ -225,11 +220,10 @@ def _setup_workers(
     writer_workers = [
         WriterWorker(
             cfg,
-            output_stores,
+            output_specs,
             write_queues[i],
             preprocess,
             full_shape,
-            accumulator_factory,
         )
         for i in range(len(write_queues))
     ]
@@ -239,7 +233,7 @@ def _setup_workers(
 def _setup_worker_threads(
     model: nn.Module,
     input_store: Any,
-    output_stores: List[Any],
+    output_specs: List[OutputSpec],
     cfg: InferenceConfig,
     stop_event: threading.Event,
     num_prep_workers: int,
@@ -247,7 +241,6 @@ def _setup_worker_threads(
     write_queues: List[queue.Queue],
     preprocess: BlockPreprocessor,
     full_shape: Tuple[int, int, int],
-    accumulator_factory: BlockAccumulatorFactory,
 ) -> Tuple[List[threading.Thread], List[threading.Thread], List[threading.Thread]]:
     """Sets up the worker threads for the pipeline.
 
@@ -257,8 +250,8 @@ def _setup_worker_threads(
         The model to use for inference.
     input_store : Any
         The input data store.
-    output_stores : List[Any]
-        One output data store per model output channel.
+    output_specs : List[OutputSpec]
+        One spec per model output channel.
     cfg : InferenceConfig
         The inference configuration.
     stop_event : threading.Event
@@ -269,6 +262,10 @@ def _setup_worker_threads(
         The prep queue.
     write_queues : List[queue.Queue]
         A list of writer queues.
+    preprocess : BlockPreprocessor
+        The injected block transform shared by prep and writer.
+    full_shape : Tuple[int, int, int]
+        Full volume spatial shape ``(Z, Y, X)``.
 
     Returns
     -------
@@ -280,14 +277,13 @@ def _setup_worker_threads(
     prep_workers, gpu_workers, writer_workers = _setup_workers(
         model,
         input_store,
-        output_stores,
+        output_specs,
         cfg,
         num_prep_workers,
         prep_q,
         write_queues,
         preprocess,
         full_shape,
-        accumulator_factory,
     )
 
     # Threads
@@ -307,16 +303,59 @@ def _setup_worker_threads(
     return prep_threads, gpu_threads, writer_threads
 
 
+def _resolve_output_specs(
+    output_store: Union[Any, List[Any], None],
+    outputs: Optional[List[OutputSpec]],
+    cfg: InferenceConfig,
+) -> List[OutputSpec]:
+    """Return the per-output specs, synthesizing them from ``output_store`` if needed.
+
+    Exactly one of ``output_store`` / ``outputs`` must be provided. When synthesizing,
+    each store gets the default trim/blend merge and ``invert=cfg.output_denormalize``,
+    reproducing the pre-refactor single-policy writer.
+    """
+    if outputs is not None:
+        if output_store is not None:
+            raise ValueError("Pass either output_store or outputs, not both.")
+        if not outputs:
+            raise ValueError("outputs must be a non-empty list of OutputSpec.")
+        return outputs
+
+    if output_store is None:
+        raise ValueError("Provide output_store (or outputs).")
+
+    output_stores = (
+        output_store if isinstance(output_store, list) else [output_store]
+    )
+    factory = weighted_average_factory(
+        cfg.eps,
+        cfg.overlap,
+        cfg.seam_mode,
+        cfg.trim_voxels,
+        cfg.min_blend_weight,
+    )
+    return [
+        OutputSpec(
+            store=store,
+            accumulator_factory=factory,
+            postprocess=None,
+            invert=cfg.output_denormalize,
+        )
+        for store in output_stores
+    ]
+
+
 def run(
     model: nn.Module,
     input_store: Any,
-    output_store: Union[Any, List[Any]],
+    output_store: Union[Any, List[Any], None],
     cfg: InferenceConfig,
     metrics_json: Optional[str] = None,
     metrics_interval: float = 0.5,
     num_prep_workers: int = 1,
     num_writer_workers: int = 1,
     preprocess: Optional[BlockPreprocessor] = None,
+    outputs: Optional[List[OutputSpec]] = None,
 ) -> None:
     """Runs the inference pipeline.
 
@@ -325,12 +364,13 @@ def run(
     model : nn.Module
         The model to use for inference. For multi-output models (e.g.,
         SharedEncoderModel) the forward pass must return a tensor of shape
-        ``(B, N, Z, Y, X)`` and ``output_store`` must be a list of N stores.
+        ``(B, N, Z, Y, X)`` and there must be N outputs.
     input_store : Any
         The input data store.
-    output_store : Any or list of Any
+    output_store : Any or list of Any or None
         Output TensorStore(s). Pass a single store for single-output models, or
-        a list of N stores when the model returns N output channels.
+        a list of N stores when the model returns N output channels. May be
+        ``None`` only when ``outputs`` is given.
     cfg : InferenceConfig
         The inference configuration.
     metrics_json : Optional[str], optional
@@ -346,11 +386,13 @@ def run(
         the writer). When ``None`` (default), one is synthesized from the legacy
         config fields (``normalize``/``norm_lower``/``norm_upper``/``clip_norm``),
         preserving existing behavior.
+    outputs : Optional[List[OutputSpec]], optional
+        Per-output specs (store + merge factory + post-processor + invert flag).
+        When ``None`` (default), specs are synthesized from ``output_store`` with
+        the default trim/blend merge and ``invert=cfg.output_denormalize`` for
+        every output, preserving existing behavior. Provide this for per-output
+        merge/post/dtype control; ``output_store`` is then optional.
     """
-    output_stores: List[Any] = (
-        output_store if isinstance(output_store, list) else [output_store]
-    )
-
     # Validate shapes
     T, C, Z, Y, X = tuple(input_store.domain.shape)
     assert 0 <= cfg.t_idx < T and 0 <= cfg.c_idx < C, "Invalid t/c indices"
@@ -366,14 +408,10 @@ def run(
             cfg.clip_norm,
         )
 
-    # Default merge factory reproduces the historical trim/blend accumulator.
-    accumulator_factory = weighted_average_factory(
-        cfg.eps,
-        cfg.overlap,
-        cfg.seam_mode,
-        cfg.trim_voxels,
-        cfg.min_blend_weight,
-    )
+    # Resolve the per-output specs. Explicit `outputs` win; otherwise synthesize
+    # one spec per store with the default trim/blend merge and a per-output invert
+    # flag driven by cfg.output_denormalize -- byte-identical to the old writer.
+    output_specs = _resolve_output_specs(output_store, outputs, cfg)
 
     # Queues
     prep_q, write_queues = _setup_queues(
@@ -391,7 +429,7 @@ def run(
     prep_threads, gpu_threads, writer_threads = _setup_worker_threads(
         model,
         input_store,
-        output_stores,
+        output_specs,
         cfg,
         stop_event,
         num_prep_workers,
@@ -399,7 +437,6 @@ def run(
         write_queues,
         preprocess,
         (Z, Y, X),
-        accumulator_factory,
     )
     all_threads = prep_threads + gpu_threads + writer_threads
 

--- a/src/aind_torch_utils/run.py
+++ b/src/aind_torch_utils/run.py
@@ -19,6 +19,10 @@ from torch import nn
 
 import aind_torch_utils.models  # This registers all models when imported
 from aind_torch_utils import transforms
+from aind_torch_utils.accumulators import (
+    BlockAccumulatorFactory,
+    weighted_average_factory,
+)
 from aind_torch_utils.config import InferenceConfig
 from aind_torch_utils.model_registry import ModelRegistry
 from aind_torch_utils.monitoring import QueueMonitor, SystemMonitor
@@ -170,6 +174,7 @@ def _setup_workers(
     write_queues: List[queue.Queue],
     preprocess: BlockPreprocessor,
     full_shape: Tuple[int, int, int],
+    accumulator_factory: BlockAccumulatorFactory,
 ) -> Tuple[List[PrepWorker], List[GpuWorker], List[WriterWorker]]:
     """Sets up the workers for the pipeline.
 
@@ -193,6 +198,8 @@ def _setup_workers(
         The injected block transform shared by prep (forward) and writer (inverse).
     full_shape : Tuple[int, int, int]
         Full volume spatial shape ``(Z, Y, X)``.
+    accumulator_factory : BlockAccumulatorFactory
+        Builds the per-block merge accumulators in each writer.
 
     Returns
     -------
@@ -216,7 +223,14 @@ def _setup_workers(
         for device in cfg.devices
     ]
     writer_workers = [
-        WriterWorker(cfg, output_stores, write_queues[i], preprocess, full_shape)
+        WriterWorker(
+            cfg,
+            output_stores,
+            write_queues[i],
+            preprocess,
+            full_shape,
+            accumulator_factory,
+        )
         for i in range(len(write_queues))
     ]
     return prep_workers, gpu_workers, writer_workers
@@ -233,6 +247,7 @@ def _setup_worker_threads(
     write_queues: List[queue.Queue],
     preprocess: BlockPreprocessor,
     full_shape: Tuple[int, int, int],
+    accumulator_factory: BlockAccumulatorFactory,
 ) -> Tuple[List[threading.Thread], List[threading.Thread], List[threading.Thread]]:
     """Sets up the worker threads for the pipeline.
 
@@ -272,6 +287,7 @@ def _setup_worker_threads(
         write_queues,
         preprocess,
         full_shape,
+        accumulator_factory,
     )
 
     # Threads
@@ -350,6 +366,15 @@ def run(
             cfg.clip_norm,
         )
 
+    # Default merge factory reproduces the historical trim/blend accumulator.
+    accumulator_factory = weighted_average_factory(
+        cfg.eps,
+        cfg.overlap,
+        cfg.seam_mode,
+        cfg.trim_voxels,
+        cfg.min_blend_weight,
+    )
+
     # Queues
     prep_q, write_queues = _setup_queues(
         num_writer_workers, maxsize=cfg.max_inflight_batches
@@ -374,6 +399,7 @@ def run(
         write_queues,
         preprocess,
         (Z, Y, X),
+        accumulator_factory,
     )
     all_threads = prep_threads + gpu_threads + writer_threads
 

--- a/src/aind_torch_utils/run.py
+++ b/src/aind_torch_utils/run.py
@@ -21,6 +21,7 @@ import aind_torch_utils.models  # This registers all models when imported
 from aind_torch_utils import transforms
 from aind_torch_utils.accumulators import weighted_average_factory
 from aind_torch_utils.config import InferenceConfig
+from aind_torch_utils.execution import ExecutionPolicy
 from aind_torch_utils.model_registry import ModelRegistry
 from aind_torch_utils.monitoring import QueueMonitor, SystemMonitor
 from aind_torch_utils.outputs import OutputSpec
@@ -172,6 +173,7 @@ def _setup_workers(
     write_queues: List[queue.Queue],
     preprocess: BlockPreprocessor,
     full_shape: Tuple[int, int, int],
+    execution: ExecutionPolicy,
 ) -> Tuple[List[PrepWorker], List[GpuWorker], List[WriterWorker]]:
     """Sets up the workers for the pipeline.
 
@@ -195,6 +197,8 @@ def _setup_workers(
         The injected block transform shared by prep (forward) and writer (inverse).
     full_shape : Tuple[int, int, int]
         Full volume spatial shape ``(Z, Y, X)``.
+    execution : ExecutionPolicy
+        How the GPU processor runs (dtype/autocast/compile/channels_last).
 
     Returns
     -------
@@ -208,13 +212,14 @@ def _setup_workers(
             prep_q,
             cfg.patch,
             preprocess,
+            execution,
             worker_id=i,
             num_workers=num_prep_workers,
         )
         for i in range(max(1, num_prep_workers))
     ]
     gpu_workers = [
-        GpuWorker(cfg, deepcopy(model), device, prep_q, write_queues)
+        GpuWorker(cfg, deepcopy(model), device, prep_q, write_queues, execution)
         for device in cfg.devices
     ]
     writer_workers = [
@@ -241,6 +246,7 @@ def _setup_worker_threads(
     write_queues: List[queue.Queue],
     preprocess: BlockPreprocessor,
     full_shape: Tuple[int, int, int],
+    execution: ExecutionPolicy,
 ) -> Tuple[List[threading.Thread], List[threading.Thread], List[threading.Thread]]:
     """Sets up the worker threads for the pipeline.
 
@@ -284,6 +290,7 @@ def _setup_worker_threads(
         write_queues,
         preprocess,
         full_shape,
+        execution,
     )
 
     # Threads
@@ -356,6 +363,7 @@ def run(
     num_writer_workers: int = 1,
     preprocess: Optional[BlockPreprocessor] = None,
     outputs: Optional[List[OutputSpec]] = None,
+    execution: Optional[ExecutionPolicy] = None,
 ) -> None:
     """Runs the inference pipeline.
 
@@ -392,6 +400,11 @@ def run(
         the default trim/blend merge and ``invert=cfg.output_denormalize`` for
         every output, preserving existing behavior. Provide this for per-output
         merge/post/dtype control; ``output_store`` is then optional.
+    execution : Optional[ExecutionPolicy], optional
+        How the GPU processor runs (input dtype / autocast / inference_mode /
+        compile / channels_last). When ``None`` (default), synthesized from cfg
+        (``amp``/``use_compile``/``compile_mode``/``compile_dynamic``), so AMP-on
+        stays the legacy default.
     """
     # Validate shapes
     T, C, Z, Y, X = tuple(input_store.domain.shape)
@@ -412,6 +425,12 @@ def run(
     # one spec per store with the default trim/blend merge and a per-output invert
     # flag driven by cfg.output_denormalize -- byte-identical to the old writer.
     output_specs = _resolve_output_specs(output_store, outputs, cfg)
+
+    # Default execution policy from cfg keeps AMP/compile behavior identical.
+    if execution is None:
+        execution = ExecutionPolicy.from_config(
+            cfg.amp, cfg.use_compile, cfg.compile_mode, cfg.compile_dynamic
+        )
 
     # Queues
     prep_q, write_queues = _setup_queues(
@@ -437,6 +456,7 @@ def run(
         write_queues,
         preprocess,
         (Z, Y, X),
+        execution,
     )
     all_threads = prep_threads + gpu_threads + writer_threads
 

--- a/src/aind_torch_utils/run.py
+++ b/src/aind_torch_utils/run.py
@@ -174,7 +174,6 @@ def _setup_workers(
     prep_q: queue.Queue,
     write_queues: List[queue.Queue],
     preprocess: BlockPreprocessor,
-    full_shape: Tuple[int, int, int],
     execution: ExecutionPolicy,
 ) -> Tuple[List[PrepWorker], List[GpuWorker], List[WriterWorker]]:
     """Sets up the workers for the pipeline.
@@ -197,8 +196,6 @@ def _setup_workers(
         A list of writer queues.
     preprocess : BlockPreprocessor
         The injected block transform shared by prep (forward) and writer (inverse).
-    full_shape : Tuple[int, int, int]
-        Full volume spatial shape ``(Z, Y, X)``.
     execution : ExecutionPolicy
         How the GPU processor runs (dtype/autocast/compile/channels_last).
 
@@ -220,8 +217,18 @@ def _setup_workers(
         )
         for i in range(max(1, num_prep_workers))
     ]
+    # Per-device copies only make sense for nn.Modules (independent weights on
+    # each GPU). A plain-callable BlockProcessor is shared as-is: it manages
+    # its own state and may hold handles deepcopy cannot pickle.
     gpu_workers = [
-        GpuWorker(cfg, deepcopy(model), device, prep_q, write_queues, execution)
+        GpuWorker(
+            cfg,
+            deepcopy(model) if isinstance(model, nn.Module) else model,
+            device,
+            prep_q,
+            write_queues,
+            execution,
+        )
         for device in cfg.devices
     ]
     writer_workers = [
@@ -230,11 +237,33 @@ def _setup_workers(
             output_specs,
             write_queues[i],
             preprocess,
-            full_shape,
         )
         for i in range(len(write_queues))
     ]
     return prep_workers, gpu_workers, writer_workers
+
+
+def _guarded_worker(
+    run_fn: Any,
+    stop_event: threading.Event,
+    errors: List[Tuple[str, BaseException]],
+    name: str,
+) -> Any:
+    """Wrap a worker's run() so an uncaught exception stops the pipeline.
+
+    Without this, a dead worker leaves its peers spinning on full queues
+    forever (hang) or lets run() return "successfully" with nothing written.
+    """
+
+    def target() -> None:
+        try:
+            run_fn(stop_event)
+        except Exception as exc:  # noqa: BLE001 - any worker death is fatal
+            logger.exception("Worker thread %s died; stopping pipeline.", name)
+            errors.append((name, exc))
+            stop_event.set()
+
+    return target
 
 
 def _setup_worker_threads(
@@ -247,8 +276,8 @@ def _setup_worker_threads(
     prep_q: queue.Queue,
     write_queues: List[queue.Queue],
     preprocess: BlockPreprocessor,
-    full_shape: Tuple[int, int, int],
     execution: ExecutionPolicy,
+    worker_errors: List[Tuple[str, BaseException]],
 ) -> Tuple[List[threading.Thread], List[threading.Thread], List[threading.Thread]]:
     """Sets up the worker threads for the pipeline.
 
@@ -272,8 +301,11 @@ def _setup_worker_threads(
         A list of writer queues.
     preprocess : BlockPreprocessor
         The injected block transform shared by prep and writer.
-    full_shape : Tuple[int, int, int]
-        Full volume spatial shape ``(Z, Y, X)``.
+    execution : ExecutionPolicy
+        How the GPU processor runs.
+    worker_errors : list
+        Receives ``(thread_name, exception)`` for any worker that dies; the
+        caller re-raises after joins so failures are never silent.
 
     Returns
     -------
@@ -291,21 +323,29 @@ def _setup_worker_threads(
         prep_q,
         write_queues,
         preprocess,
-        full_shape,
         execution,
     )
 
     # Threads
     prep_threads = [
-        threading.Thread(target=w.run, args=(stop_event,), name=f"prep-{i}")
+        threading.Thread(
+            target=_guarded_worker(w.run, stop_event, worker_errors, f"prep-{i}"),
+            name=f"prep-{i}",
+        )
         for i, w in enumerate(prep_workers)
     ]
     gpu_threads = [
-        threading.Thread(target=worker.run, args=(stop_event,), name=f"gpu-{i}")
-        for i, worker in enumerate(gpu_workers)
+        threading.Thread(
+            target=_guarded_worker(w.run, stop_event, worker_errors, f"gpu-{i}"),
+            name=f"gpu-{i}",
+        )
+        for i, w in enumerate(gpu_workers)
     ]
     writer_threads = [
-        threading.Thread(target=w.run, args=(stop_event,), name=f"writer-{i}")
+        threading.Thread(
+            target=_guarded_worker(w.run, stop_event, worker_errors, f"writer-{i}"),
+            name=f"writer-{i}",
+        )
         for i, w in enumerate(writer_workers)
     ]
 
@@ -328,6 +368,14 @@ def _resolve_output_specs(
             raise ValueError("Pass either output_store or outputs, not both.")
         if not outputs:
             raise ValueError("outputs must be a non-empty list of OutputSpec.")
+        # Catch a None store here, in the caller's thread, instead of as an
+        # opaque AttributeError when the first block completes in a writer.
+        for i, spec in enumerate(outputs):
+            if spec.store is None:
+                raise ValueError(
+                    f"OutputSpec {i} has store=None; every output needs a "
+                    "destination store."
+                )
         return outputs
 
     if output_store is None:
@@ -352,6 +400,38 @@ def _resolve_output_specs(
         )
         for store in output_stores
     ]
+
+
+_KNOWN_INVERSE_STAGES = ("before_accumulate", "after_finalize")
+
+
+def _validate_inversion(
+    preprocess: BlockPreprocessor, output_specs: List[OutputSpec]
+) -> None:
+    """Fail fast on inversion misconfiguration, before any thread starts.
+
+    The writer silently skips inversion when its stage gates do not match, so a
+    non-invertible preprocess paired with ``invert=True`` (or an unrecognized
+    ``inverse_stage`` string) would otherwise write normalized-space data with
+    no error.
+    """
+    if not transforms.is_invertible(preprocess):
+        if any(spec.invert for spec in output_specs):
+            raise ValueError(
+                "An OutputSpec requests invert=True but the preprocess "
+                f"({type(preprocess).__name__}) defines no inverse. Set "
+                "invert=False (or cfg.output_denormalize=False) to write "
+                "outputs untransformed, or use an invertible preprocess."
+            )
+        return
+    # May raise for Sequential members that disagree — better here than in a
+    # writer thread.
+    stage = getattr(preprocess, "inverse_stage", "after_finalize")
+    if stage not in _KNOWN_INVERSE_STAGES:
+        raise ValueError(
+            f"Unknown inverse_stage {stage!r} on {type(preprocess).__name__}; "
+            f"expected one of {_KNOWN_INVERSE_STAGES}."
+        )
 
 
 def run(
@@ -428,6 +508,9 @@ def run(
     # flag driven by cfg.output_denormalize -- byte-identical to the old writer.
     output_specs = _resolve_output_specs(output_store, outputs, cfg)
 
+    # Fail fast (in this thread) on invert/inverse_stage misconfiguration.
+    _validate_inversion(preprocess, output_specs)
+
     # Default execution policy from cfg keeps AMP/compile behavior identical.
     if execution is None:
         execution = ExecutionPolicy.from_config(
@@ -446,6 +529,10 @@ def run(
         prep_q, write_queues, metrics_interval, stop_event
     )
 
+    # Collects (thread_name, exception) from any worker that dies; re-raised
+    # after joins so a failed run never looks like a successful one.
+    worker_errors: List[Tuple[str, BaseException]] = []
+
     # Threads
     prep_threads, gpu_threads, writer_threads = _setup_worker_threads(
         model,
@@ -457,8 +544,8 @@ def run(
         prep_q,
         write_queues,
         preprocess,
-        (Z, Y, X),
         execution,
+        worker_errors,
     )
     all_threads = prep_threads + gpu_threads + writer_threads
 
@@ -516,6 +603,12 @@ def run(
         if metrics_json:
             _write_metrics_json(metrics_json, q_monitor, sys_monitor)
 
+    if worker_errors:
+        names = ", ".join(name for name, _ in worker_errors)
+        raise RuntimeError(
+            f"Worker thread(s) failed: {names}; see logged tracebacks."
+        ) from worker_errors[0][1]
+
     t1 = time.perf_counter()
     throughput = (Z * Y * X * input_store.dtype.numpy_dtype.itemsize) / 1e6 / (t1 - t0)
     logger.info(f"Total time: {t1-t0:.2f}s")
@@ -538,16 +631,25 @@ def run_workflow(
     Parameters
     ----------
     workflow : Workflow
-        The recipe to run.
+        The recipe to run. When the workflow leaves ``preprocess`` or
+        ``execution`` unset (``None``), :func:`run` synthesizes them from
+        ``cfg``, so config/CLI normalization and AMP/compile flags apply; a
+        recipe sets them to pin its own behavior.
     input_store : Any
         The input data store.
     output_store : Any or list of Any or None
-        Output store(s). Ignored when the workflow supplies its own ``outputs``.
+        Output store(s). Ignored when the workflow supplies its own ``outputs``;
+        required when it supplies an ``output_spec_factory``.
     cfg : InferenceConfig
         The runtime configuration.
     **run_kwargs : Any
         Forwarded to :func:`run` (e.g. ``metrics_json``, ``num_prep_workers``).
     """
+    if workflow.output_spec_factory is not None and output_store is None:
+        raise ValueError(
+            "This workflow builds its output specs from the opened output "
+            "stores; provide output_store."
+        )
     output_stores = (
         output_store if isinstance(output_store, list) else [output_store]
     )
@@ -611,8 +713,12 @@ def _parse_args(argv: List[str]) -> argparse.Namespace:
         "--out-spec",
         type=str,
         nargs="+",
-        required=True,
-        help="Path(s) to output TensorStore JSON spec file(s). Provide one per model output channel.",
+        default=None,
+        help=(
+            "Path(s) to output TensorStore JSON spec file(s). Provide one per "
+            "model output channel. Required unless the workflow supplies its "
+            "own fixed outputs."
+        ),
     )
     ap.add_argument(
         "--model-type",
@@ -796,9 +902,13 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     if bool(args.model_type) == bool(args.workflow):
         raise SystemExit("Provide exactly one of --model-type or --workflow.")
+    if args.workflow and args.weights:
+        raise SystemExit(
+            "--weights only applies with --model-type; pass weights to the "
+            "workflow via --workflow-params."
+        )
 
     in_arr = open_ts_spec(args.in_spec)
-    out_arr = [open_ts_spec(s) for s in args.out_spec]
 
     cfg = InferenceConfig(
         patch=tuple(args.patch),
@@ -847,8 +957,28 @@ def main(argv: Optional[List[str]] = None) -> None:
             with open(args.workflow_params) as f:
                 params = json.load(f)
         workflow = WorkflowRegistry.build(args.workflow, params)
+        # Decide the stores' fate BEFORE opening them: an open with a
+        # create/delete_existing spec mutates the target, and a fixed-outputs
+        # workflow would then silently ignore it.
+        if workflow.outputs is not None:
+            if args.out_spec:
+                raise SystemExit(
+                    f"Workflow '{args.workflow}' supplies its own outputs; "
+                    "remove --out-spec (it would be ignored)."
+                )
+            out_arr = None
+        else:
+            if not args.out_spec:
+                raise SystemExit(
+                    f"--out-spec is required: workflow '{args.workflow}' does "
+                    "not supply fixed outputs."
+                )
+            out_arr = [open_ts_spec(s) for s in args.out_spec]
         run_workflow(workflow, in_arr, out_arr, cfg, **run_kwargs)
     else:
+        if not args.out_spec:
+            raise SystemExit("--out-spec is required with --model-type.")
+        out_arr = [open_ts_spec(s) for s in args.out_spec]
         model = load_model(args.model_type, args.weights)
         run(model, in_arr, out_arr, cfg, **run_kwargs)
 

--- a/src/aind_torch_utils/transforms.py
+++ b/src/aind_torch_utils/transforms.py
@@ -98,11 +98,34 @@ class _AffineNormalizer:
     inverse_stage: InverseStage = "after_finalize"
 
     def __init__(self, eps: float = 1e-6):
+        """Initialize the inverse transform.
+
+        Parameters
+        ----------
+        eps : float, optional
+            Minimum affine scale used during inversion.
+        """
         self.eps = float(eps)
 
     def inverse(
         self, block: np.ndarray, state: Any, ctx: "BlockContext"
     ) -> np.ndarray:
+        """Invert affine normalization on a block.
+
+        Parameters
+        ----------
+        block : np.ndarray
+            Normalized block to invert.
+        state : tuple of float
+            Lower and upper bounds saved during normalization.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        np.ndarray
+            Denormalized float32 block.
+        """
         mn, mx = state
         scale = max(mx - mn, self.eps)
         return (block * np.float32(scale) + np.float32(mn)).astype(
@@ -119,6 +142,17 @@ class PercentileNormalizer(_AffineNormalizer):
     """
 
     def __init__(self, lower: float, upper: float, eps: float = 1e-6):
+        """Initialize the percentile normalizer.
+
+        Parameters
+        ----------
+        lower : float
+            Lower percentile used as the zero point.
+        upper : float
+            Upper percentile used as the unit point.
+        eps : float, optional
+            Minimum normalization scale.
+        """
         super().__init__(eps=eps)
         self.lower = float(lower)
         self.upper = float(upper)
@@ -126,6 +160,22 @@ class PercentileNormalizer(_AffineNormalizer):
     def forward(
         self, block: np.ndarray, ctx: "BlockContext"
     ) -> Tuple[np.ndarray, Any]:
+        """Normalize a block using its percentile bounds.
+
+        Parameters
+        ----------
+        block : np.ndarray
+            Input block to normalize.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        normalized : np.ndarray
+            Float32 block normalized by its percentile range.
+        state : tuple of float
+            Lower and upper percentile values used for inversion.
+        """
         block = _as_float32(block)
         mn, mx = np.percentile(block, [self.lower, self.upper])
         scale = max(mx - mn, self.eps)
@@ -141,6 +191,17 @@ class GlobalNormalizer(_AffineNormalizer):
     """
 
     def __init__(self, lower: float, upper: float, eps: float = 1e-6):
+        """Initialize the global normalizer.
+
+        Parameters
+        ----------
+        lower : float
+            Fixed lower clipping and normalization bound.
+        upper : float
+            Fixed upper clipping and normalization bound.
+        eps : float, optional
+            Minimum normalization scale.
+        """
         super().__init__(eps=eps)
         self.lower = float(lower)
         self.upper = float(upper)
@@ -148,6 +209,22 @@ class GlobalNormalizer(_AffineNormalizer):
     def forward(
         self, block: np.ndarray, ctx: "BlockContext"
     ) -> Tuple[np.ndarray, Any]:
+        """Clip and normalize a block using fixed bounds.
+
+        Parameters
+        ----------
+        block : np.ndarray
+            Input block to normalize.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        normalized : np.ndarray
+            Clipped and normalized float32 block.
+        state : tuple of float
+            Fixed lower and upper bounds used for inversion.
+        """
         lo, hi = self.lower, self.upper
         scale = max(hi - lo, self.eps)
         out = np.clip(block, lo, hi)
@@ -167,11 +244,43 @@ class IdentityTransform:
     def forward(
         self, block: np.ndarray, ctx: "BlockContext"
     ) -> Tuple[np.ndarray, Any]:
+        """Apply the identity transform.
+
+        Parameters
+        ----------
+        block : np.ndarray
+            Input block.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        transformed : np.ndarray
+            The original block.
+        state : None
+            No transform state is required.
+        """
         return block, None
 
     def inverse(
         self, block: np.ndarray, state: Any, ctx: "BlockContext"
     ) -> np.ndarray:
+        """Invert the identity transform.
+
+        Parameters
+        ----------
+        block : np.ndarray
+            Block to invert.
+        state : Any
+            Ignored transform state.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        np.ndarray
+            The original block.
+        """
         return block
 
 
@@ -183,12 +292,37 @@ class Clip:
     """
 
     def __init__(self, lo: float, hi: float):
+        """Initialize the clip transform.
+
+        Parameters
+        ----------
+        lo : float
+            Inclusive lower clipping bound.
+        hi : float
+            Inclusive upper clipping bound.
+        """
         self.lo = float(lo)
         self.hi = float(hi)
 
     def forward(
         self, block: np.ndarray, ctx: "BlockContext"
     ) -> Tuple[np.ndarray, Any]:
+        """Clip a block to the configured bounds.
+
+        Parameters
+        ----------
+        block : np.ndarray
+            Input block to clip.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        transformed : np.ndarray
+            Clipped block.
+        state : None
+            No transform state is produced.
+        """
         return np.clip(block, self.lo, self.hi), None
 
 
@@ -201,10 +335,29 @@ class Sequential:
     """
 
     def __init__(self, steps: List[BlockPreprocessor]):
+        """Initialize the transform composition.
+
+        Parameters
+        ----------
+        steps : list of BlockPreprocessor
+            Transforms to apply from left to right.
+        """
         self.steps = list(steps)
 
     @property
     def inverse_stage(self) -> InverseStage:
+        """Return the shared inverse stage of invertible members.
+
+        Returns
+        -------
+        InverseStage
+            The shared stage, or ``"after_finalize"`` when none is declared.
+
+        Raises
+        ------
+        ValueError
+            If invertible members declare different inverse stages.
+        """
         stages = {
             s.inverse_stage
             for s in self.steps
@@ -220,6 +373,22 @@ class Sequential:
     def forward(
         self, block: np.ndarray, ctx: "BlockContext"
     ) -> Tuple[np.ndarray, Any]:
+        """Apply each transform in order.
+
+        Parameters
+        ----------
+        block : np.ndarray
+            Input block to transform.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        transformed : np.ndarray
+            Result after applying all transforms.
+        state : tuple
+            Per-transform states in forward order.
+        """
         states: List[Any] = []
         for step in self.steps:
             block, state = step.forward(block, ctx)
@@ -229,6 +398,22 @@ class Sequential:
     def inverse(
         self, block: np.ndarray, state: Any, ctx: "BlockContext"
     ) -> np.ndarray:
+        """Invert eligible transforms in reverse order.
+
+        Parameters
+        ----------
+        block : np.ndarray
+            Block to invert.
+        state : tuple
+            Per-transform states returned by :meth:`forward`.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        np.ndarray
+            Block after applying all available inverse transforms.
+        """
         for step, step_state in zip(reversed(self.steps), reversed(state)):
             if is_invertible(step):
                 block = step.inverse(block, step_state, ctx)

--- a/src/aind_torch_utils/transforms.py
+++ b/src/aind_torch_utils/transforms.py
@@ -43,6 +43,10 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 # "after_finalize": invert once per block after merge (correct + fast for linear
 #   inverses; the default). "before_accumulate": invert each patch before merge
 #   (needed only when a nonlinear inverse must not commute with averaging).
+#   Limitation: the writer passes before_accumulate inverses the *block-level*
+#   context and no per-patch offset, so spatially-varying inverses that index
+#   ctx coordinates are not yet supported on that path — use after_finalize or
+#   a spatially-uniform inverse.
 InverseStage = str
 
 

--- a/src/aind_torch_utils/transforms.py
+++ b/src/aind_torch_utils/transforms.py
@@ -1,0 +1,287 @@
+"""Block-scoped input transforms injected into the tiled-inference runtime.
+
+A **preprocessor** is an input-domain operation applied to each block *before* it is
+tiled into patches (normalization, calibration correction, ...). The runtime treats a
+preprocessor as an opaque object with two contracts:
+
+``forward(block, ctx) -> (block, state)``
+    Runs in the prep stage. ``state`` is an opaque, **per-block** blob (see
+    :class:`~aind_torch_utils.workers.Batch.transform_state`); return ``None`` when
+    nothing needs to travel to the writer.
+
+``inverse(block, state, ctx) -> block`` *(invertible transforms only)*
+    Runs in the writer stage. Normalization is the canonical invertible transform:
+    the affine denormalization is the mathematical inverse of the affine
+    normalization, so both halves live in **one** class and the state schema is that
+    class's private business rather than a contract two classes must secretly share.
+
+Keeping forward + inverse in one object is the point of
+:class:`InvertibleBlockTransform`: splitting them would re-introduce the coupling
+this refactor removes (issue #25 §3.2).
+
+The concrete normalizers here reproduce the exact arithmetic the ``PrepWorker`` used
+to inline, so wiring them in (PR2b) leaves existing runs byte-for-byte identical.
+"""
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+    runtime_checkable,
+)
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from aind_torch_utils.context import BlockContext
+
+
+# "after_finalize": invert once per block after merge (correct + fast for linear
+#   inverses; the default). "before_accumulate": invert each patch before merge
+#   (needed only when a nonlinear inverse must not commute with averaging).
+InverseStage = str
+
+
+@runtime_checkable
+class BlockPreprocessor(Protocol):
+    """Input-domain op applied per block. Returns ``(block, state)``.
+
+    ``state`` is opaque, per-block, and travels to the writer only for invertible
+    transforms; a one-way preprocessor returns ``None``.
+    """
+
+    def forward(
+        self, block: np.ndarray, ctx: "BlockContext"
+    ) -> Tuple[np.ndarray, Any]:
+        """Apply the transform to ``block`` and return ``(block, state)``."""
+        ...
+
+
+@runtime_checkable
+class InvertibleBlockTransform(BlockPreprocessor, Protocol):
+    """A preprocessor whose effect on model outputs can be undone in the writer.
+
+    ``inverse_stage`` declares where the writer must apply :meth:`inverse` relative
+    to seam merging (see :data:`InverseStage`).
+    """
+
+    inverse_stage: InverseStage
+
+    def inverse(
+        self, block: np.ndarray, state: Any, ctx: "BlockContext"
+    ) -> np.ndarray:
+        """Undo :meth:`forward` on a finalized output block using ``state``."""
+        ...
+
+
+def is_invertible(obj: Any) -> bool:
+    """True if ``obj`` exposes an ``inverse`` method (duck-typed, not isinstance)."""
+    return callable(getattr(obj, "inverse", None))
+
+
+class _AffineNormalizer:
+    """Shared affine inverse for the linear normalizers.
+
+    ``state`` is the ``(mn, mx)`` pair each subclass records in :meth:`forward`; the
+    inverse maps a normalized value ``v`` back to ``v * max(mx - mn, eps) + mn`` in
+    float32 -- exactly what the writer used to compute per patch.
+    """
+
+    inverse_stage: InverseStage = "after_finalize"
+
+    def __init__(self, eps: float = 1e-6):
+        self.eps = float(eps)
+
+    def inverse(
+        self, block: np.ndarray, state: Any, ctx: "BlockContext"
+    ) -> np.ndarray:
+        mn, mx = state
+        scale = max(mx - mn, self.eps)
+        return (block * np.float32(scale) + np.float32(mn)).astype(
+            np.float32, copy=False
+        )
+
+
+class PercentileNormalizer(_AffineNormalizer):
+    """Normalize a block to [0, 1] using its own ``[lower, upper]`` percentiles.
+
+    Mirrors the legacy ``normalize="percentile"`` path: percentiles are computed over
+    the whole (expanded) block and the block is affinely rescaled **in place** on the
+    float32 array the prep stage owns.
+    """
+
+    def __init__(self, lower: float, upper: float, eps: float = 1e-6):
+        super().__init__(eps=eps)
+        self.lower = float(lower)
+        self.upper = float(upper)
+
+    def forward(
+        self, block: np.ndarray, ctx: "BlockContext"
+    ) -> Tuple[np.ndarray, Any]:
+        block = _as_float32(block)
+        mn, mx = np.percentile(block, [self.lower, self.upper])
+        scale = max(mx - mn, self.eps)
+        block -= mn
+        block /= scale
+        return block, (float(mn), float(mx))
+
+
+class GlobalNormalizer(_AffineNormalizer):
+    """Clip a block to a fixed ``[lower, upper]`` range, then rescale to [0, 1].
+
+    Mirrors the legacy ``normalize="global"`` path (clip first, then normalize).
+    """
+
+    def __init__(self, lower: float, upper: float, eps: float = 1e-6):
+        super().__init__(eps=eps)
+        self.lower = float(lower)
+        self.upper = float(upper)
+
+    def forward(
+        self, block: np.ndarray, ctx: "BlockContext"
+    ) -> Tuple[np.ndarray, Any]:
+        lo, hi = self.lower, self.upper
+        scale = max(hi - lo, self.eps)
+        out = np.clip(block, lo, hi)
+        out = (out - lo) / scale
+        return out.astype(np.float32, copy=False), (float(lo), float(hi))
+
+
+class IdentityTransform:
+    """No-op invertible transform (legacy ``normalize=False``).
+
+    Carries no state and its inverse returns the block unchanged, so an output that
+    "inverts" through it is written exactly as the model produced it.
+    """
+
+    inverse_stage: InverseStage = "after_finalize"
+
+    def forward(
+        self, block: np.ndarray, ctx: "BlockContext"
+    ) -> Tuple[np.ndarray, Any]:
+        return block, None
+
+    def inverse(
+        self, block: np.ndarray, state: Any, ctx: "BlockContext"
+    ) -> np.ndarray:
+        return block
+
+
+class Clip:
+    """One-way clip of the (normalized) block to ``[lo, hi]``. Non-invertible.
+
+    Mirrors the legacy ``clip_norm`` step, which ran after normalization. It only
+    affects the model input, so it produces no state and defines no ``inverse``.
+    """
+
+    def __init__(self, lo: float, hi: float):
+        self.lo = float(lo)
+        self.hi = float(hi)
+
+    def forward(
+        self, block: np.ndarray, ctx: "BlockContext"
+    ) -> Tuple[np.ndarray, Any]:
+        return np.clip(block, self.lo, self.hi), None
+
+
+class Sequential:
+    """Compose preprocessors left-to-right; invert the invertible members in reverse.
+
+    The composite ``state`` is the tuple of member states (opaque to the runtime).
+    :meth:`inverse` walks the members back-to-front and applies ``inverse`` only on
+    those that define it, so non-invertible steps (e.g. :class:`Clip`) are skipped.
+    """
+
+    def __init__(self, steps: List[BlockPreprocessor]):
+        self.steps = list(steps)
+
+    @property
+    def inverse_stage(self) -> InverseStage:
+        stages = {
+            s.inverse_stage
+            for s in self.steps
+            if is_invertible(s) and hasattr(s, "inverse_stage")
+        }
+        if len(stages) > 1:
+            raise ValueError(
+                f"Sequential members disagree on inverse_stage: {stages}. "
+                "Compose transforms that invert in the same stage."
+            )
+        return stages.pop() if stages else "after_finalize"
+
+    def forward(
+        self, block: np.ndarray, ctx: "BlockContext"
+    ) -> Tuple[np.ndarray, Any]:
+        states: List[Any] = []
+        for step in self.steps:
+            block, state = step.forward(block, ctx)
+            states.append(state)
+        return block, tuple(states)
+
+    def inverse(
+        self, block: np.ndarray, state: Any, ctx: "BlockContext"
+    ) -> np.ndarray:
+        for step, step_state in zip(reversed(self.steps), reversed(state)):
+            if is_invertible(step):
+                block = step.inverse(block, step_state, ctx)
+        return block
+
+
+def _as_float32(block: np.ndarray) -> np.ndarray:
+    """Return ``block`` as float32, without copying when it already is.
+
+    The prep stage passes a float32 block it owns, so callers there get in-place
+    normalization (matching the legacy hot path); other callers get a safe copy.
+    """
+    if block.dtype == np.float32:
+        return block
+    return block.astype(np.float32)
+
+
+def from_config(
+    normalize: Any,
+    norm_lower: float,
+    norm_upper: float,
+    eps: float,
+    clip_norm: Any,
+) -> BlockPreprocessor:
+    """Synthesize the default preprocessor from legacy config fields.
+
+    This is the bridge that keeps ``run()`` backward-compatible: when no explicit
+    ``preprocess`` is injected, the runtime builds the transform these fields used to
+    describe. The result is byte-for-byte equivalent to the old inline prep path.
+
+    Parameters
+    ----------
+    normalize : {"percentile", "global"} or False
+        Normalization strategy (``InferenceConfig.normalize``).
+    norm_lower, norm_upper : float
+        Percentiles (percentile mode) or the clip range (global mode).
+    eps : float
+        Division epsilon.
+    clip_norm : bool or (float, float)
+        ``True`` clips the normalized block to [0, 1]; a pair clips to that range;
+        ``False`` disables clipping. Applied after normalization, as before.
+    """
+    if normalize == "percentile":
+        base: BlockPreprocessor = PercentileNormalizer(norm_lower, norm_upper, eps)
+    elif normalize == "global":
+        base = GlobalNormalizer(norm_lower, norm_upper, eps)
+    else:  # False / disabled
+        base = IdentityTransform()
+
+    clip: Optional[Clip] = None
+    if clip_norm:
+        if clip_norm is True:
+            clip = Clip(0.0, 1.0)
+        else:
+            lo, hi = clip_norm
+            clip = Clip(lo, hi)
+
+    if clip is None:
+        return base
+    return Sequential([base, clip])

--- a/src/aind_torch_utils/utils.py
+++ b/src/aind_torch_utils/utils.py
@@ -1,3 +1,5 @@
+"""General TensorStore and three-dimensional tiling utilities."""
+
 from __future__ import annotations
 
 import json
@@ -140,6 +142,22 @@ def iter_patch_starts(
     )
 
     def axis_starts(L: int, P: int, S: int) -> List[int]:
+        """Return covering patch starts for one axis.
+
+        Parameters
+        ----------
+        L : int
+            Length of the block axis.
+        P : int
+            Length of the patch axis.
+        S : int
+            Step between adjacent patches.
+
+        Returns
+        -------
+        list of int
+            Patch starts, including the final boundary-aligned start.
+        """
         if L <= P:
             return [0]
         starts = list(range(0, L - P + 1, S))

--- a/src/aind_torch_utils/workers.py
+++ b/src/aind_torch_utils/workers.py
@@ -42,8 +42,12 @@ class Batch:
     valid_sizes : List[Tuple[int, int, int]]
         List of (dz, dy, dx) valid dimensions for each patch, handling
         boundary conditions.
-    per_block_minmax : List[Tuple[float, float]]
-        List of (min, max) percentile values for each patch used for normalization.
+    transform_state : Any
+        Opaque, **per-block** state produced by the preprocessing/normalization step
+        and consumed (only) by its inverse in the writer. The runtime never inspects
+        it. Today it holds the affine ``(mn, mx)`` used for inverse normalization; a
+        future preprocessor may store anything its paired inverse needs (or ``None``
+        when no inversion is required).
     total_patches_in_block : int
         The total number of patches in the entire block.
     acc_shape : Tuple[int, int, int]
@@ -58,7 +62,7 @@ class Batch:
     starts_in_block: List[Tuple[int, int, int]]
     host_in: torch.Tensor
     valid_sizes: List[Tuple[int, int, int]]
-    per_block_minmax: List[Tuple[float, float]]  # per-patch (mn, mx)
+    transform_state: Any  # opaque, per-block (today: affine (mn, mx))
     total_patches_in_block: int
     acc_shape: Tuple[int, int, int]  # shape of expanded (core+halo) accumulator
     halo_left: Tuple[int, int, int]  # halo size on the -Z/-Y/-X sides
@@ -84,8 +88,10 @@ class Preds:
         The output tensor of predictions, pinned to host memory.
     valid_sizes : List[Tuple[int, int, int]]
         List of (dz, dy, dx) valid dimensions for each patch.
-    per_block_minmax : List[Tuple[float, float]]
-        List of (min, max) percentile values for each patch for denormalization.
+    transform_state : Any
+        Opaque, **per-block** state passed through from the matching :class:`Batch`
+        (the GPU stage does not touch it) and consumed by the preprocessing inverse
+        in the writer. Today it holds the affine ``(mn, mx)`` for denormalization.
     total_patches_in_block : int
         The total number of patches in the entire block.
     acc_shape : Tuple[int, int, int]
@@ -102,7 +108,7 @@ class Preds:
     starts_in_block: List[Tuple[int, int, int]]
     host_out: torch.Tensor
     valid_sizes: List[Tuple[int, int, int]]
-    per_block_minmax: List[Tuple[float, float]]
+    transform_state: Any
     total_patches_in_block: int
     acc_shape: Tuple[int, int, int]
     halo_left: Tuple[int, int, int]
@@ -261,6 +267,11 @@ class PrepWorker:
             starts = starts_cache[(bz, by, bx)]
             total_patches = len(starts)
 
+            # Opaque per-block state for the writer's inverse normalization. The whole
+            # block shares one (mn, mx), so it is computed once here rather than per
+            # patch. Future preprocessors can store any inverse state (or None).
+            transform_state = (float(block_mn), float(block_mx))
+
             # batch over those starts
             for i in range(0, total_patches, self.cfg.batch_size):
                 batch_starts = starts[i : i + self.cfg.batch_size]
@@ -279,7 +290,7 @@ class PrepWorker:
                     dtype=torch.float16 if self.cfg.amp else torch.float32,
                     pin_memory=pin_memory,
                 )
-                valid_sizes, per_block_minmax = [], []
+                valid_sizes = []
 
                 for bi, (sz, sy, sx) in enumerate(batch_starts):
                     ez, ey, ex = (
@@ -295,8 +306,6 @@ class PrepWorker:
                     host_in[bi, 0, :dz, :dy, :dx].copy_(torch.from_numpy(norm))
 
                     valid_sizes.append((dz, dy, dx))
-                    # Every patch in the block uses the same (mn, mx)
-                    per_block_minmax.append((float(block_mn), float(block_mx)))
 
                 batch = Batch(
                     block_idx=block_idx,
@@ -305,7 +314,7 @@ class PrepWorker:
                     starts_in_block=batch_starts,  # coords are in expanded space
                     host_in=host_in,
                     valid_sizes=valid_sizes,
-                    per_block_minmax=per_block_minmax,
+                    transform_state=transform_state,
                     total_patches_in_block=total_patches,
                     acc_shape=acc_shape,
                     halo_left=halo_left,
@@ -502,7 +511,7 @@ class GpuWorker:
                 starts_in_block=batch.starts_in_block,
                 host_out=host_out,
                 valid_sizes=batch.valid_sizes,
-                per_block_minmax=batch.per_block_minmax,  # pass-through
+                transform_state=batch.transform_state,  # opaque pass-through
                 total_patches_in_block=batch.total_patches_in_block,
                 acc_shape=batch.acc_shape,
                 halo_left=batch.halo_left,
@@ -627,20 +636,25 @@ class WriterWorker:
                     f"writer(s) for block {preds.block_idx}."
                 )
 
+            # Inverse normalization is the same affine map for every patch in the
+            # block, so resolve it once from the per-block transform_state. This is
+            # useful whenever the model output maps back to the original data range;
+            # disabled (e.g. for a segmentation model) via output_denormalize=False.
+            denorm: Optional[Tuple[np.float32, np.float32]] = None
+            if self.cfg.output_denormalize:
+                mn, mx = preds.transform_state
+                scale = max(mx - mn, self.cfg.eps)
+                denorm = (np.float32(scale), np.float32(mn))
+
             for bi, (sz, sy, sx) in enumerate(preds.starts_in_block):
                 dz, dy, dx = preds.valid_sizes[bi]
                 for n, acc in enumerate(accs):
                     patch_pred = out_np[bi, n]
                     pp = patch_pred.astype(np.float32, copy=False)
 
-                    # This is useful for whenever the model does not need
-                    # to map to the original data range (e.g. a segmentation model)
-                    if self.cfg.output_denormalize:
-                        mn, mx = preds.per_block_minmax[bi]
-                        scale = max(mx - mn, self.cfg.eps)
-                        pp = (pp * np.float32(scale) + np.float32(mn)).astype(
-                            np.float32, copy=False
-                        )
+                    if denorm is not None:
+                        scale, mn = denorm
+                        pp = (pp * scale + mn).astype(np.float32, copy=False)
                     acc.add(pp, (sz, sy, sx), (dz, dy, dx))
 
             if accs[0].count >= accs[0].total:

--- a/src/aind_torch_utils/workers.py
+++ b/src/aind_torch_utils/workers.py
@@ -3,16 +3,17 @@ import queue
 import threading
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import tensorstore as ts
 import torch
 from torch import nn
 
-from aind_torch_utils.accumulators import BlockAccumulator, BlockAccumulatorFactory
+from aind_torch_utils.accumulators import BlockAccumulator
 from aind_torch_utils.config import InferenceConfig
 from aind_torch_utils.context import BlockContext
+from aind_torch_utils.outputs import OutputSpec
 from aind_torch_utils.transforms import BlockPreprocessor, is_invertible
 from aind_torch_utils.utils import iter_blocks_zyx, iter_patch_starts
 
@@ -525,19 +526,23 @@ class WriterWorker:
     """
     Worker that accumulates predictions for a block and writes the result.
 
-    Supports single-output models (legacy: one writer) and multi-output models
-    (N writers, one per decoder). The model output tensor is expected to have
-    shape ``(B, N, Z, Y, X)`` where N equals ``len(writers)``.
+    Each model output channel is described by an :class:`OutputSpec` carrying its
+    own merge accumulator, optional post-processor, inversion flag, and destination
+    store. The model output tensor is expected to have shape ``(B, N, Z, Y, X)``
+    where N equals ``len(outputs)``.
+
+    Per block, once complete, each output is finalized through the ordered pipeline
+    (issue #25 §4.4): ``finalize -> invert (if requested) -> postprocess -> crop
+    halo -> cast to store dtype -> write``.
     """
 
     def __init__(
         self,
         cfg: InferenceConfig,
-        writers: "Union[ts.TensorStore, List[ts.TensorStore]]",
+        outputs: List[OutputSpec],
         write_q: "queue.Queue[Optional[Preds]]",
         preprocess: BlockPreprocessor,
         full_shape: Tuple[int, int, int],
-        accumulator_factory: BlockAccumulatorFactory,
     ):
         """
         Initializes the WriterWorker.
@@ -546,39 +551,41 @@ class WriterWorker:
         ----------
         cfg : InferenceConfig
             The inference configuration.
-        writers : ts.TensorStore or list of ts.TensorStore
-            One output store per model output channel. A bare TensorStore is
-            treated as a single-element list for backwards compatibility.
+        outputs : list of OutputSpec
+            One spec per model output channel: store + merge factory + optional
+            post-processor + per-output ``invert`` flag.
         write_q : queue.Queue[Optional[Preds]]
             The queue from which to get model predictions.
         preprocess : BlockPreprocessor
-            The same transform the prep stage applied. If it is invertible and
-            ``cfg.output_denormalize`` is set, its ``inverse`` is applied to each
-            finalized (expanded) output block using the per-block
-            ``transform_state`` carried on ``Preds``.
+            The same transform the prep stage applied. Its ``inverse`` is applied
+            to the outputs whose ``OutputSpec.invert`` is set (only when it is
+            invertible), using the per-block ``transform_state`` carried on
+            ``Preds``. The transform's ``inverse_stage`` decides whether inversion
+            happens per patch (``before_accumulate``) or once per finalized block
+            (``after_finalize``).
         full_shape : Tuple[int, int, int]
             Full volume spatial shape ``(Z, Y, X)``; used to rebuild the
-            :class:`BlockContext` for the inverse.
-        accumulator_factory : BlockAccumulatorFactory
-            Builds one accumulator per block per output. Determines how
-            overlapping patches merge (average / max / majority / ...). Defaults,
-            when synthesized from config, reproduce the historical trim/blend merge.
+            :class:`BlockContext` passed to hooks.
         """
         self.cfg = cfg
-        self.writers: List["ts.TensorStore"] = (
-            writers if isinstance(writers, list) else [writers]
-        )
+        self.outputs = outputs
         self.write_q = write_q
         self.preprocess = preprocess
         self.full_shape = full_shape
-        self.accumulator_factory = accumulator_factory
         # maps block_idx → list of BlockAccumulator, one per output channel
         self.blocks: Dict[Tuple[int, int, int], List[BlockAccumulator]] = {}
 
     def _make_accumulators(
-        self, acc_shape: Tuple[int, int, int], ctx: "BlockContext"
+        self, acc_shape: Tuple[int, int, int], ctx: BlockContext
     ) -> List[BlockAccumulator]:
-        return [self.accumulator_factory(acc_shape, ctx) for _ in self.writers]
+        return [spec.accumulator_factory(acc_shape, ctx) for spec in self.outputs]
+
+    def _cast_to_store(self, core: np.ndarray, store: Any) -> np.ndarray:
+        target_dtype = store.dtype.numpy_dtype
+        if np.issubdtype(target_dtype, np.integer):
+            info = np.iinfo(target_dtype)
+            return np.clip(core, info.min, info.max).astype(target_dtype, copy=False)
+        return core.astype(target_dtype, copy=False)
 
     def run(self, stop_event: threading.Event) -> None:
         """
@@ -592,6 +599,9 @@ class WriterWorker:
         stop_event : threading.Event
             An event that signals the worker to stop.
         """
+        invertible = is_invertible(self.preprocess)
+        inverse_stage = self.preprocess.inverse_stage if invertible else None
+
         while not stop_event.is_set():
             try:
                 preds = self.write_q.get(timeout=0.1)
@@ -612,7 +622,7 @@ class WriterWorker:
             )
 
             # Block placement is identical for every Preds of this block; build it
-            # once for both accumulator construction and the inverse below.
+            # once for accumulator construction, per-patch inversion, and finalize.
             ctx = BlockContext.from_preds(
                 preds, self.full_shape, self.cfg.t_idx, self.cfg.c_idx
             )
@@ -625,7 +635,7 @@ class WriterWorker:
                 self.blocks[preds.block_idx] = accs
 
             out_np = preds.host_out.numpy()  # (B, N, pz, py, px) or (B, 1, pz, py, px)
-            # Ensure the tensor has a channel dimension that matches writers
+            # Ensure the tensor has a channel dimension that matches the outputs
             if out_np.ndim == 4:
                 # legacy single-output (B, pz, py, px) — add channel dim
                 out_np = out_np[:, np.newaxis]
@@ -636,51 +646,38 @@ class WriterWorker:
                     f"(or legacy (B, Z, Y, X)); got shape {out_np.shape}"
                 )
 
-            if out_np.shape[1] != len(self.writers):
+            if out_np.shape[1] != len(self.outputs):
                 raise ValueError(
-                    "Mismatch between model output channels and output stores: "
-                    f"got N={out_np.shape[1]} channels but {len(self.writers)} "
-                    f"writer(s) for block {preds.block_idx}."
+                    "Mismatch between model output channels and output specs: "
+                    f"got N={out_np.shape[1]} channels but {len(self.outputs)} "
+                    f"output(s) for block {preds.block_idx}."
                 )
 
-            # Patches are merged in the transform's *output* space; the invertible
-            # transform's inverse (denormalization) is applied once per block after
-            # finalize (see below), not per patch. This is correct for linear
-            # inverses and strictly cheaper than the old per-patch denorm.
+            # Merge patches in the transform's *output* space. For an output that
+            # inverts with a nonlinear transform declaring 'before_accumulate', the
+            # inverse must run per patch (it does not commute with averaging); the
+            # common linear case inverts once per block after finalize (below).
             for bi, (sz, sy, sx) in enumerate(preds.starts_in_block):
                 dz, dy, dx = preds.valid_sizes[bi]
-                for n, acc in enumerate(accs):
+                for n, (spec, acc) in enumerate(zip(self.outputs, accs)):
                     pp = out_np[bi, n].astype(np.float32, copy=False)
+                    if spec.invert and inverse_stage == "before_accumulate":
+                        pp = self.preprocess.inverse(pp, preds.transform_state, ctx)
                     acc.add(pp, (sz, sy, sx), (dz, dy, dx))
 
             if accs[0].count >= accs[0].total:
                 lz, ly, lx = preds.halo_left
-                # Apply the transform's inverse once per block (after_finalize) when
-                # the transform is invertible and denormalization is requested.
-                # before_accumulate (invert per patch) is handled by the per-output
-                # pipeline (PR4).
-                invert = self.cfg.output_denormalize and is_invertible(self.preprocess)
-                if invert and self.preprocess.inverse_stage != "after_finalize":
-                    raise NotImplementedError(
-                        "inverse_stage='before_accumulate' is not supported by the "
-                        "single-policy writer; use per-output OutputSpec (PR4)."
-                    )
-                for acc, writer in zip(accs, self.writers):
-                    ext = acc.finalize()
-                    if invert:
+                for spec, acc in zip(self.outputs, accs):
+                    ext = acc.finalize()  # expanded (core + halo)
+                    if spec.invert and inverse_stage == "after_finalize":
                         ext = self.preprocess.inverse(
                             ext, preds.transform_state, ctx
                         )
+                    if spec.postprocess is not None:
+                        ext = spec.postprocess(ext, ctx)
                     core = ext[lz : lz + core_bz, ly : ly + core_by, lx : lx + core_bx]
-                    target_dtype = writer.dtype.numpy_dtype
-                    if np.issubdtype(target_dtype, np.integer):
-                        info = np.iinfo(target_dtype)
-                        out_arr = np.clip(core, info.min, info.max).astype(
-                            target_dtype, copy=False
-                        )
-                    else:
-                        out_arr = core.astype(target_dtype, copy=False)
-                    writer[self.cfg.t_idx, self.cfg.c_idx, zsl, ysl, xsl].write(
+                    out_arr = self._cast_to_store(core, spec.store)
+                    spec.store[self.cfg.t_idx, self.cfg.c_idx, zsl, ysl, xsl].write(
                         out_arr
                     ).result()
                 del self.blocks[preds.block_idx]

--- a/src/aind_torch_utils/workers.py
+++ b/src/aind_torch_utils/workers.py
@@ -10,7 +10,7 @@ import tensorstore as ts
 import torch
 from torch import nn
 
-from aind_torch_utils.accumulators import BlockAccumulator
+from aind_torch_utils.accumulators import BlockAccumulator, BlockAccumulatorFactory
 from aind_torch_utils.config import InferenceConfig
 from aind_torch_utils.context import BlockContext
 from aind_torch_utils.transforms import BlockPreprocessor, is_invertible
@@ -537,6 +537,7 @@ class WriterWorker:
         write_q: "queue.Queue[Optional[Preds]]",
         preprocess: BlockPreprocessor,
         full_shape: Tuple[int, int, int],
+        accumulator_factory: BlockAccumulatorFactory,
     ):
         """
         Initializes the WriterWorker.
@@ -558,6 +559,10 @@ class WriterWorker:
         full_shape : Tuple[int, int, int]
             Full volume spatial shape ``(Z, Y, X)``; used to rebuild the
             :class:`BlockContext` for the inverse.
+        accumulator_factory : BlockAccumulatorFactory
+            Builds one accumulator per block per output. Determines how
+            overlapping patches merge (average / max / majority / ...). Defaults,
+            when synthesized from config, reproduce the historical trim/blend merge.
         """
         self.cfg = cfg
         self.writers: List["ts.TensorStore"] = (
@@ -566,21 +571,14 @@ class WriterWorker:
         self.write_q = write_q
         self.preprocess = preprocess
         self.full_shape = full_shape
+        self.accumulator_factory = accumulator_factory
         # maps block_idx → list of BlockAccumulator, one per output channel
         self.blocks: Dict[Tuple[int, int, int], List[BlockAccumulator]] = {}
 
-    def _make_accumulators(self, acc_shape: Tuple[int, int, int]) -> List[BlockAccumulator]:
-        return [
-            BlockAccumulator(
-                acc_shape,
-                self.cfg.eps,
-                overlap=self.cfg.overlap,
-                seam_mode=self.cfg.seam_mode,
-                trim_voxels=self.cfg.trim_voxels,
-                min_blend_weight=self.cfg.min_blend_weight,
-            )
-            for _ in self.writers
-        ]
+    def _make_accumulators(
+        self, acc_shape: Tuple[int, int, int], ctx: "BlockContext"
+    ) -> List[BlockAccumulator]:
+        return [self.accumulator_factory(acc_shape, ctx) for _ in self.writers]
 
     def run(self, stop_event: threading.Event) -> None:
         """
@@ -613,9 +611,15 @@ class WriterWorker:
                 xsl.stop - xsl.start,
             )
 
+            # Block placement is identical for every Preds of this block; build it
+            # once for both accumulator construction and the inverse below.
+            ctx = BlockContext.from_preds(
+                preds, self.full_shape, self.cfg.t_idx, self.cfg.c_idx
+            )
+
             accs = self.blocks.get(preds.block_idx)
             if accs is None:
-                accs = self._make_accumulators(preds.acc_shape)
+                accs = self._make_accumulators(preds.acc_shape, ctx)
                 for acc in accs:
                     acc.total = preds.total_patches_in_block
                 self.blocks[preds.block_idx] = accs
@@ -651,13 +655,10 @@ class WriterWorker:
 
             if accs[0].count >= accs[0].total:
                 lz, ly, lx = preds.halo_left
-                # Rebuild the block context for the inverse. Apply the transform's
-                # inverse once per block (after_finalize) when the transform is
-                # invertible and denormalization is requested. before_accumulate
-                # (invert per patch) is handled in the per-output pipeline (PR4).
-                ctx = BlockContext.from_preds(
-                    preds, self.full_shape, self.cfg.t_idx, self.cfg.c_idx
-                )
+                # Apply the transform's inverse once per block (after_finalize) when
+                # the transform is invertible and denormalization is requested.
+                # before_accumulate (invert per patch) is handled by the per-output
+                # pipeline (PR4).
                 invert = self.cfg.output_denormalize and is_invertible(self.preprocess)
                 if invert and self.preprocess.inverse_stage != "after_finalize":
                     raise NotImplementedError(

--- a/src/aind_torch_utils/workers.py
+++ b/src/aind_torch_utils/workers.py
@@ -13,7 +13,7 @@ from torch import nn
 from aind_torch_utils.accumulators import BlockAccumulator
 from aind_torch_utils.config import InferenceConfig
 from aind_torch_utils.context import BlockContext
-from aind_torch_utils.execution import ExecutionPolicy
+from aind_torch_utils.execution import ExecutionPolicy, cuda_safe_compile_mode
 from aind_torch_utils.outputs import OutputSpec
 from aind_torch_utils.transforms import BlockPreprocessor, is_invertible
 from aind_torch_utils.utils import iter_blocks_zyx, iter_patch_starts
@@ -58,6 +58,9 @@ class Batch:
         The shape of the expanded (core + halo) accumulator for this block.
     halo_left : Tuple[int, int, int]
         The size of the halo on the (-z, -y, -x) sides of the block.
+    ctx : BlockContext
+        Absolute placement of the block, built once in the prep stage and
+        carried through to the writer so both stages share one derivation.
     """
 
     block_idx: Tuple[int, int, int]
@@ -70,6 +73,7 @@ class Batch:
     total_patches_in_block: int
     acc_shape: Tuple[int, int, int]  # shape of expanded (core+halo) accumulator
     halo_left: Tuple[int, int, int]  # halo size on the -Z/-Y/-X sides
+    ctx: BlockContext
 
 
 @dataclass(slots=True)
@@ -102,6 +106,9 @@ class Preds:
         The shape of the expanded (core + halo) accumulator for this block.
     halo_left : Tuple[int, int, int]
         The size of the halo on the (-z, -y, -x) sides of the block.
+    ctx : BlockContext
+        Absolute placement of the block, passed through unchanged from the
+        matching :class:`Batch` (the GPU stage does not touch it).
     ready_event : Optional[torch.cuda.Event]
         A CUDA event that signals when the D2H copy of `host_out` is complete.
     """
@@ -116,6 +123,7 @@ class Preds:
     total_patches_in_block: int
     acc_shape: Tuple[int, int, int]
     halo_left: Tuple[int, int, int]
+    ctx: BlockContext
     # CUDA event to signal the D2H copy completed
     ready_event: Optional["torch.cuda.Event"] = field(
         default=None, repr=False, compare=False
@@ -235,8 +243,6 @@ class PrepWorker:
             y0e, y1e = max(y0 - halo, 0), min(y1 + halo, Y)
             x0e, x1e = max(x0 - halo, 0), min(x1 + halo, X)
 
-            # how much halo was actually added on the - sides
-            halo_left = (z0 - z0e, y0 - y0e, x0 - x0e)
             acc_shape = (z1e - z0e, y1e - y0e, x1e - x0e)
 
             # absolute expanded bbox: used to read the block and to place it in the
@@ -250,6 +256,8 @@ class PrepWorker:
                 t_idx=t,
                 c_idx=c,
             )
+            # how much halo was actually added on the - sides (derived once, in ctx)
+            halo_left = ctx.halo_left
 
             # read expanded block and cast to float32 for the injected transform
             ez_sl, ey_sl, ex_sl = expanded_bbox
@@ -317,6 +325,7 @@ class PrepWorker:
                     total_patches_in_block=total_patches,
                     acc_shape=acc_shape,
                     halo_left=halo_left,
+                    ctx=ctx,
                 )
                 while not stop_event.is_set():
                     try:
@@ -347,8 +356,11 @@ class GpuWorker:
         ----------
         cfg : InferenceConfig
             The denoising configuration.
-        model : nn.Module
-            The PyTorch model to run.
+        model : nn.Module or callable
+            The processor to run. An ``nn.Module`` is moved to the device and
+            put in eval mode; any other tensor-in/tensor-out callable (see
+            :class:`~aind_torch_utils.workflow.BlockProcessor`) is used as-is
+            and manages its own device placement.
         device : str
             The CUDA device to use (e.g., "cuda:0").
         prep_q : queue.Queue[Optional[Batch]]
@@ -371,10 +383,15 @@ class GpuWorker:
         torch.backends.cuda.matmul.allow_tf32 = self.cfg.use_tf32
         torch.backends.cudnn.benchmark = self.cfg.cudnn_benchmark
 
-        self.model.to(self.device)
-        if self.execution.channels_last:
-            self.model = self.model.to(memory_format=torch.channels_last_3d)
-        self.model.eval()
+        # BlockProcessor promises "any callable" works: only nn.Modules get
+        # device placement / eval; plain callables manage their own state.
+        if isinstance(self.model, nn.Module):
+            self.model.to(self.device)
+            if self.execution.channels_last:
+                self.model = self.model.to(
+                    memory_format=torch.channels_last_3d
+                )
+            self.model.eval()
 
         self.copy_stream = torch.cuda.Stream(device=self.device)
 
@@ -398,6 +415,22 @@ class GpuWorker:
         # execution if compilation fails. torch.compile returns a new wrapper
         # and does not mutate the original, so this reference stays valid.
         eager_model = self.model
+        # InferenceConfig._validate applies the same downgrade for the default
+        # (config-synthesized) policy; a directly-injected ExecutionPolicy
+        # bypasses that validator, so guard here too: CUDA-graph capture runs
+        # lazily on a worker thread and aborts with
+        # cudaErrorStreamCaptureInvalidated.
+        compile_mode = self.execution.compile_mode
+        if self.device.type == "cuda":
+            safe_mode = cuda_safe_compile_mode(compile_mode)
+            if safe_mode != compile_mode:
+                logger.warning(
+                    "torch.compile mode %r enables CUDA graphs, which fail in "
+                    "this pipeline's threaded GPU workers; using %r instead.",
+                    compile_mode,
+                    safe_mode,
+                )
+                compile_mode = safe_mode
         try:
             try:
                 # PrepWorker pads tail batches to batch_size, so input shapes
@@ -405,15 +438,13 @@ class GpuWorker:
                 # regardless of the `dynamic` setting.
                 self.model = torch.compile(
                     self.model,
-                    mode=self.execution.compile_mode,
+                    mode=compile_mode,
                     dynamic=self.execution.compile_dynamic,
                 )
                 logger.info("Compiled model on %s.", self.device)
             except TypeError:
                 # older PyTorch without `dynamic` kwarg
-                self.model = torch.compile(
-                    self.model, mode=self.execution.compile_mode
-                )
+                self.model = torch.compile(self.model, mode=compile_mode)
                 logger.info("Compiled model on %s (older pytorch).", self.device)
 
             # Compilation is lazy: the graph is traced on the first forward,
@@ -533,6 +564,7 @@ class GpuWorker:
                 total_patches_in_block=batch.total_patches_in_block,
                 acc_shape=batch.acc_shape,
                 halo_left=batch.halo_left,
+                ctx=batch.ctx,
                 ready_event=evt,  # <-- writer will synchronize this
             )
 
@@ -546,6 +578,19 @@ class GpuWorker:
                     break
                 except queue.Full:
                     continue
+
+
+@dataclass
+class _BlockState:
+    """Writer-side bookkeeping for one in-flight block.
+
+    The writer counts merged patches itself (``seen``), so accumulators only
+    merge; an accumulator cannot silently stall block completion by forgetting
+    counter plumbing.
+    """
+
+    accs: List[BlockAccumulator]
+    seen: int = 0
 
 
 class WriterWorker:
@@ -568,7 +613,6 @@ class WriterWorker:
         outputs: List[OutputSpec],
         write_q: "queue.Queue[Optional[Preds]]",
         preprocess: BlockPreprocessor,
-        full_shape: Tuple[int, int, int],
     ):
         """
         Initializes the WriterWorker.
@@ -589,17 +633,13 @@ class WriterWorker:
             ``Preds``. The transform's ``inverse_stage`` decides whether inversion
             happens per patch (``before_accumulate``) or once per finalized block
             (``after_finalize``).
-        full_shape : Tuple[int, int, int]
-            Full volume spatial shape ``(Z, Y, X)``; used to rebuild the
-            :class:`BlockContext` passed to hooks.
         """
         self.cfg = cfg
         self.outputs = outputs
         self.write_q = write_q
         self.preprocess = preprocess
-        self.full_shape = full_shape
-        # maps block_idx → list of BlockAccumulator, one per output channel
-        self.blocks: Dict[Tuple[int, int, int], List[BlockAccumulator]] = {}
+        # maps block_idx → in-flight accumulation state for that block
+        self.blocks: Dict[Tuple[int, int, int], _BlockState] = {}
 
     def _make_accumulators(
         self, acc_shape: Tuple[int, int, int], ctx: BlockContext
@@ -626,7 +666,14 @@ class WriterWorker:
             An event that signals the worker to stop.
         """
         invertible = is_invertible(self.preprocess)
-        inverse_stage = self.preprocess.inverse_stage if invertible else None
+        # Duck-typed invertible transforms may omit inverse_stage; default to
+        # the common linear case (matching Sequential's fallback) instead of
+        # dying with AttributeError. run() validates the value up front.
+        inverse_stage = (
+            getattr(self.preprocess, "inverse_stage", "after_finalize")
+            if invertible
+            else None
+        )
 
         while not stop_event.is_set():
             try:
@@ -647,18 +694,17 @@ class WriterWorker:
                 xsl.stop - xsl.start,
             )
 
-            # Block placement is identical for every Preds of this block; build it
-            # once for accumulator construction, per-patch inversion, and finalize.
-            ctx = BlockContext.from_preds(
-                preds, self.full_shape, self.cfg.t_idx, self.cfg.c_idx
-            )
+            # Block placement is identical for every Preds of this block; it was
+            # built once in the prep stage and rides on the carrier.
+            ctx = preds.ctx
 
-            accs = self.blocks.get(preds.block_idx)
-            if accs is None:
-                accs = self._make_accumulators(preds.acc_shape, ctx)
-                for acc in accs:
-                    acc.total = preds.total_patches_in_block
-                self.blocks[preds.block_idx] = accs
+            state = self.blocks.get(preds.block_idx)
+            if state is None:
+                state = _BlockState(
+                    accs=self._make_accumulators(preds.acc_shape, ctx)
+                )
+                self.blocks[preds.block_idx] = state
+            accs = state.accs
 
             out_np = preds.host_out.numpy()  # (B, N, pz, py, px) or (B, 1, pz, py, px)
             # Ensure the tensor has a channel dimension that matches the outputs
@@ -690,8 +736,9 @@ class WriterWorker:
                     if spec.invert and inverse_stage == "before_accumulate":
                         pp = self.preprocess.inverse(pp, preds.transform_state, ctx)
                     acc.add(pp, (sz, sy, sx), (dz, dy, dx))
+            state.seen += len(preds.starts_in_block)
 
-            if accs[0].count >= accs[0].total:
+            if state.seen >= preds.total_patches_in_block:
                 lz, ly, lx = preds.halo_left
                 for spec, acc in zip(self.outputs, accs):
                     ext = acc.finalize()  # expanded (core + halo)

--- a/src/aind_torch_utils/workers.py
+++ b/src/aind_torch_utils/workers.py
@@ -12,6 +12,8 @@ from torch import nn
 
 from aind_torch_utils.accumulators import BlockAccumulator
 from aind_torch_utils.config import InferenceConfig
+from aind_torch_utils.context import BlockContext
+from aind_torch_utils.transforms import BlockPreprocessor, is_invertible
 from aind_torch_utils.utils import iter_blocks_zyx, iter_patch_starts
 
 logger = logging.getLogger(__name__)
@@ -148,6 +150,7 @@ class PrepWorker:
         reader: "ts.TensorStore",
         prep_q: "queue.Queue[Batch]",
         model_patch: Tuple[int, int, int],
+        preprocess: BlockPreprocessor,
         worker_id: int = 0,
         num_workers: int = 1,
     ):
@@ -164,6 +167,12 @@ class PrepWorker:
             The queue to which prepared batches will be added.
         model_patch : Tuple[int, int, int]
             The (z, y, x) size of the model's input patches.
+        preprocess : BlockPreprocessor
+            Injected input-domain transform applied to each block. Its
+            ``forward(block, ctx)`` returns the processed block and an opaque
+            per-block ``transform_state`` carried to the writer. The prep stage
+            no longer branches on normalization mode; that logic lives in the
+            transform object (see :mod:`aind_torch_utils.transforms`).
         worker_id : int, optional
             The ID of this worker, by default 0.
         num_workers : int, optional
@@ -173,6 +182,7 @@ class PrepWorker:
         self.reader = reader
         self.prep_q = prep_q
         self.patch = model_patch
+        self.preprocess = preprocess
         self.full_zyx = self.reader.shape[-3:]
         self.worker_id = worker_id
         self.num_workers = max(1, num_workers)
@@ -221,43 +231,29 @@ class PrepWorker:
             halo_left = (z0 - z0e, y0 - y0e, x0 - x0e)
             acc_shape = (z1e - z0e, y1e - y0e, x1e - x0e)
 
-            # read expanded block and cast to float32 for normalization
-            view = self.reader[t, c, slice(z0e, z1e), slice(y0e, y1e), slice(x0e, x1e)]
+            # absolute expanded bbox: used to read the block and to place it in the
+            # volume for the injected transform (seam-free coordinate sampling).
+            expanded_bbox = (slice(z0e, z1e), slice(y0e, y1e), slice(x0e, x1e))
+            ctx = BlockContext.from_block(
+                block_idx=block_idx,
+                core_bbox=core_bbox,
+                expanded_bbox=expanded_bbox,
+                full_shape=(Z, Y, X),
+                t_idx=t,
+                c_idx=c,
+            )
+
+            # read expanded block and cast to float32 for the injected transform
+            ez_sl, ey_sl, ex_sl = expanded_bbox
+            view = self.reader[t, c, ez_sl, ey_sl, ex_sl]
             norm_block = view.read().result().astype(np.float32, copy=False)
             bz, by, bx = acc_shape
 
-            if self.cfg.normalize == "percentile":
-                block_mn, block_mx = np.percentile(
-                    norm_block,
-                    [
-                        self.cfg.norm_lower,
-                        self.cfg.norm_upper,
-                    ],
-                )
-                block_scale = max(block_mx - block_mn, self.cfg.eps)
-                # normalize the block in-place
-                norm_block -= block_mn
-                norm_block /= block_scale
-            elif self.cfg.normalize == "global":
-                block_mn = self.cfg.norm_lower
-                block_mx = self.cfg.norm_upper
-                block_scale = max(block_mx - block_mn, self.cfg.eps)
-                # Clip to [p_low, p_high] first, then normalize — matches
-                # PercentileNormalizationd._normalize_channel step order.
-                norm_block = np.clip(norm_block, block_mn, block_mx)
-                norm_block = (norm_block - block_mn) / block_scale
-            else:  # False
-                # Bypass normalization entirely (identity). We pretend (mn,mx)=(0,1)
-                # so the writer performs a no-op inverse transform.
-                block_mn, block_mx = 0.0, 1.0
-
-            # optional clipping
-            if self.cfg.clip_norm:
-                if self.cfg.clip_norm is True:
-                    norm_block = np.clip(norm_block, 0.0, 1.0)
-                else:
-                    lo, hi = self.cfg.clip_norm
-                    norm_block = np.clip(norm_block, lo, hi)
+            # The injected transform owns all normalization/correction math and
+            # returns opaque per-block state consumed by its inverse in the writer
+            # (None when nothing needs to travel there). The prep stage no longer
+            # branches on normalization mode.
+            norm_block, transform_state = self.preprocess.forward(norm_block, ctx)
 
             # patch starts over the expanded region (same stride/overlap)
             if (bz, by, bx) not in starts_cache:
@@ -266,11 +262,6 @@ class PrepWorker:
                 )
             starts = starts_cache[(bz, by, bx)]
             total_patches = len(starts)
-
-            # Opaque per-block state for the writer's inverse normalization. The whole
-            # block shares one (mn, mx), so it is computed once here rather than per
-            # patch. Future preprocessors can store any inverse state (or None).
-            transform_state = (float(block_mn), float(block_mx))
 
             # batch over those starts
             for i in range(0, total_patches, self.cfg.batch_size):
@@ -544,6 +535,8 @@ class WriterWorker:
         cfg: InferenceConfig,
         writers: "Union[ts.TensorStore, List[ts.TensorStore]]",
         write_q: "queue.Queue[Optional[Preds]]",
+        preprocess: BlockPreprocessor,
+        full_shape: Tuple[int, int, int],
     ):
         """
         Initializes the WriterWorker.
@@ -557,12 +550,22 @@ class WriterWorker:
             treated as a single-element list for backwards compatibility.
         write_q : queue.Queue[Optional[Preds]]
             The queue from which to get model predictions.
+        preprocess : BlockPreprocessor
+            The same transform the prep stage applied. If it is invertible and
+            ``cfg.output_denormalize`` is set, its ``inverse`` is applied to each
+            finalized (expanded) output block using the per-block
+            ``transform_state`` carried on ``Preds``.
+        full_shape : Tuple[int, int, int]
+            Full volume spatial shape ``(Z, Y, X)``; used to rebuild the
+            :class:`BlockContext` for the inverse.
         """
         self.cfg = cfg
         self.writers: List["ts.TensorStore"] = (
             writers if isinstance(writers, list) else [writers]
         )
         self.write_q = write_q
+        self.preprocess = preprocess
+        self.full_shape = full_shape
         # maps block_idx → list of BlockAccumulator, one per output channel
         self.blocks: Dict[Tuple[int, int, int], List[BlockAccumulator]] = {}
 
@@ -636,31 +639,37 @@ class WriterWorker:
                     f"writer(s) for block {preds.block_idx}."
                 )
 
-            # Inverse normalization is the same affine map for every patch in the
-            # block, so resolve it once from the per-block transform_state. This is
-            # useful whenever the model output maps back to the original data range;
-            # disabled (e.g. for a segmentation model) via output_denormalize=False.
-            denorm: Optional[Tuple[np.float32, np.float32]] = None
-            if self.cfg.output_denormalize:
-                mn, mx = preds.transform_state
-                scale = max(mx - mn, self.cfg.eps)
-                denorm = (np.float32(scale), np.float32(mn))
-
+            # Patches are merged in the transform's *output* space; the invertible
+            # transform's inverse (denormalization) is applied once per block after
+            # finalize (see below), not per patch. This is correct for linear
+            # inverses and strictly cheaper than the old per-patch denorm.
             for bi, (sz, sy, sx) in enumerate(preds.starts_in_block):
                 dz, dy, dx = preds.valid_sizes[bi]
                 for n, acc in enumerate(accs):
-                    patch_pred = out_np[bi, n]
-                    pp = patch_pred.astype(np.float32, copy=False)
-
-                    if denorm is not None:
-                        scale, mn = denorm
-                        pp = (pp * scale + mn).astype(np.float32, copy=False)
+                    pp = out_np[bi, n].astype(np.float32, copy=False)
                     acc.add(pp, (sz, sy, sx), (dz, dy, dx))
 
             if accs[0].count >= accs[0].total:
                 lz, ly, lx = preds.halo_left
+                # Rebuild the block context for the inverse. Apply the transform's
+                # inverse once per block (after_finalize) when the transform is
+                # invertible and denormalization is requested. before_accumulate
+                # (invert per patch) is handled in the per-output pipeline (PR4).
+                ctx = BlockContext.from_preds(
+                    preds, self.full_shape, self.cfg.t_idx, self.cfg.c_idx
+                )
+                invert = self.cfg.output_denormalize and is_invertible(self.preprocess)
+                if invert and self.preprocess.inverse_stage != "after_finalize":
+                    raise NotImplementedError(
+                        "inverse_stage='before_accumulate' is not supported by the "
+                        "single-policy writer; use per-output OutputSpec (PR4)."
+                    )
                 for acc, writer in zip(accs, self.writers):
                     ext = acc.finalize()
+                    if invert:
+                        ext = self.preprocess.inverse(
+                            ext, preds.transform_state, ctx
+                        )
                     core = ext[lz : lz + core_bz, ly : ly + core_by, lx : lx + core_bx]
                     target_dtype = writer.dtype.numpy_dtype
                     if np.issubdtype(target_dtype, np.integer):

--- a/src/aind_torch_utils/workers.py
+++ b/src/aind_torch_utils/workers.py
@@ -1,3 +1,5 @@
+"""Queue workers for preparing, processing, and writing inference blocks."""
+
 import logging
 import queue
 import threading
@@ -399,6 +401,13 @@ class GpuWorker:
             self._compile_model()
 
     def _autocast_context(self):
+        """Return the configured CUDA autocast context.
+
+        Returns
+        -------
+        context manager
+            CUDA autocast when enabled, otherwise a no-op context.
+        """
         return (
             torch.autocast(device_type="cuda", dtype=torch.float16)
             if self.execution.autocast
@@ -406,11 +415,19 @@ class GpuWorker:
         )
 
     def _inference_context(self):
+        """Return the configured inference context.
+
+        Returns
+        -------
+        context manager
+            Torch inference mode when enabled, otherwise a no-op context.
+        """
         if self.execution.inference_mode:
             return torch.inference_mode()
         return nullcontext()
 
     def _compile_model(self) -> None:
+        """Compile and warm up the model, falling back to eager execution."""
         # Keep a handle to the original module so we can fall back to eager
         # execution if compilation fails. torch.compile returns a new wrapper
         # and does not mutate the original, so this reference stays valid.
@@ -465,6 +482,7 @@ class GpuWorker:
             self.model = eager_model
 
     def _warmup_compiled_model(self) -> None:
+        """Run one device batch to trigger lazy model compilation."""
         torch.cuda.set_device(self.device)
         dtype = self.execution.input_dtype
         shape = (self.cfg.batch_size, 1, *self.cfg.patch)
@@ -644,9 +662,39 @@ class WriterWorker:
     def _make_accumulators(
         self, acc_shape: Tuple[int, int, int], ctx: BlockContext
     ) -> List[BlockAccumulator]:
+        """Create one accumulator for each output specification.
+
+        Parameters
+        ----------
+        acc_shape : tuple of int
+            Shape of the expanded block in ``(z, y, x)`` order.
+        ctx : BlockContext
+            Spatial context for the block.
+
+        Returns
+        -------
+        list of BlockAccumulator
+            Fresh accumulators in output specification order.
+        """
         return [spec.accumulator_factory(acc_shape, ctx) for spec in self.outputs]
 
     def _cast_to_store(self, core: np.ndarray, store: Any) -> np.ndarray:
+        """Cast a core block to a destination store's dtype.
+
+        Integer output is clipped to the representable range before casting.
+
+        Parameters
+        ----------
+        core : np.ndarray
+            Core block to cast.
+        store : Any
+            Destination TensorStore-like object exposing ``dtype.numpy_dtype``.
+
+        Returns
+        -------
+        np.ndarray
+            Block cast to the destination dtype.
+        """
         target_dtype = store.dtype.numpy_dtype
         if np.issubdtype(target_dtype, np.integer):
             info = np.iinfo(target_dtype)

--- a/src/aind_torch_utils/workers.py
+++ b/src/aind_torch_utils/workers.py
@@ -13,6 +13,7 @@ from torch import nn
 from aind_torch_utils.accumulators import BlockAccumulator
 from aind_torch_utils.config import InferenceConfig
 from aind_torch_utils.context import BlockContext
+from aind_torch_utils.execution import ExecutionPolicy
 from aind_torch_utils.outputs import OutputSpec
 from aind_torch_utils.transforms import BlockPreprocessor, is_invertible
 from aind_torch_utils.utils import iter_blocks_zyx, iter_patch_starts
@@ -38,7 +39,7 @@ class Batch:
         relative to the expanded block.
     host_in : torch.Tensor
         The input tensor of patches, pinned to host memory. When compiling
-        (cfg.use_compile), tail batches are zero-padded up to batch_size so
+        (execution.compile), tail batches are zero-padded up to batch_size so
         the model sees a constant input shape, and rows beyond
         len(starts_in_block) are padding. In eager mode it has exactly
         len(starts_in_block) rows.
@@ -152,6 +153,7 @@ class PrepWorker:
         prep_q: "queue.Queue[Batch]",
         model_patch: Tuple[int, int, int],
         preprocess: BlockPreprocessor,
+        execution: ExecutionPolicy,
         worker_id: int = 0,
         num_workers: int = 1,
     ):
@@ -174,6 +176,10 @@ class PrepWorker:
             per-block ``transform_state`` carried to the writer. The prep stage
             no longer branches on normalization mode; that logic lives in the
             transform object (see :mod:`aind_torch_utils.transforms`).
+        execution : ExecutionPolicy
+            Supplies the host ``input_dtype`` for allocated patches and whether
+            the processor is compiled (tail batches are padded to a constant
+            shape only when compiling).
         worker_id : int, optional
             The ID of this worker, by default 0.
         num_workers : int, optional
@@ -184,6 +190,7 @@ class PrepWorker:
         self.prep_q = prep_q
         self.patch = model_patch
         self.preprocess = preprocess
+        self.execution = execution
         self.full_zyx = self.reader.shape[-3:]
         self.worker_id = worker_id
         self.num_workers = max(1, num_workers)
@@ -276,10 +283,10 @@ class PrepWorker:
                 # only index rows in starts_in_block. In eager mode there is
                 # no shape constraint, so allocate exactly n_real rows and
                 # avoid wasting compute and copy bandwidth on padding.
-                n_rows = self.cfg.batch_size if self.cfg.use_compile else n_real
+                n_rows = self.cfg.batch_size if self.execution.compile else n_real
                 host_in = torch.zeros(
                     (n_rows, 1, pz, py, px),
-                    dtype=torch.float16 if self.cfg.amp else torch.float32,
+                    dtype=self.execution.input_dtype,
                     pin_memory=pin_memory,
                 )
                 valid_sizes = []
@@ -331,6 +338,7 @@ class GpuWorker:
         device: str,
         prep_q: "queue.Queue[Optional[Batch]]",
         write_queues: "List[queue.Queue[Optional[Preds]]]",
+        execution: ExecutionPolicy,
     ):
         """
         Initializes the GpuWorker.
@@ -347,6 +355,10 @@ class GpuWorker:
             The queue from which to get prepared batches.
         write_queues : List[queue.Queue[Optional[Preds]]]
             A list of queues to send predictions to, one for each writer worker.
+        execution : ExecutionPolicy
+            How to execute the processor: autocast, inference_mode, compile,
+            channels_last. Detaches these from global config so a processor's
+            constraints travel with it.
         """
         self.cfg = cfg
         self.model = model
@@ -354,24 +366,32 @@ class GpuWorker:
         self.prep_q = prep_q
         self.write_queues = write_queues
         self.num_writers = len(write_queues)
+        self.execution = execution
 
         torch.backends.cuda.matmul.allow_tf32 = self.cfg.use_tf32
         torch.backends.cudnn.benchmark = self.cfg.cudnn_benchmark
 
         self.model.to(self.device)
+        if self.execution.channels_last:
+            self.model = self.model.to(memory_format=torch.channels_last_3d)
         self.model.eval()
 
         self.copy_stream = torch.cuda.Stream(device=self.device)
 
-        if getattr(torch, "compile", None) and self.cfg.use_compile:
+        if getattr(torch, "compile", None) and self.execution.compile:
             self._compile_model()
 
     def _autocast_context(self):
         return (
             torch.autocast(device_type="cuda", dtype=torch.float16)
-            if self.cfg.amp
+            if self.execution.autocast
             else nullcontext()
         )
+
+    def _inference_context(self):
+        if self.execution.inference_mode:
+            return torch.inference_mode()
+        return nullcontext()
 
     def _compile_model(self) -> None:
         # Keep a handle to the original module so we can fall back to eager
@@ -385,13 +405,15 @@ class GpuWorker:
                 # regardless of the `dynamic` setting.
                 self.model = torch.compile(
                     self.model,
-                    mode=self.cfg.compile_mode,
-                    dynamic=self.cfg.compile_dynamic,
+                    mode=self.execution.compile_mode,
+                    dynamic=self.execution.compile_dynamic,
                 )
                 logger.info("Compiled model on %s.", self.device)
             except TypeError:
                 # older PyTorch without `dynamic` kwarg
-                self.model = torch.compile(self.model, mode=self.cfg.compile_mode)
+                self.model = torch.compile(
+                    self.model, mode=self.execution.compile_mode
+                )
                 logger.info("Compiled model on %s (older pytorch).", self.device)
 
             # Compilation is lazy: the graph is traced on the first forward,
@@ -413,14 +435,16 @@ class GpuWorker:
 
     def _warmup_compiled_model(self) -> None:
         torch.cuda.set_device(self.device)
-        dtype = torch.float16 if self.cfg.amp else torch.float32
+        dtype = self.execution.input_dtype
         shape = (self.cfg.batch_size, 1, *self.cfg.patch)
         warmup_in = torch.zeros(shape, dtype=dtype, device=self.device)
+        if self.execution.channels_last:
+            warmup_in = warmup_in.contiguous(memory_format=torch.channels_last_3d)
 
         logger.info(
             "Warming compiled model on %s with shape %s.", self.device, shape
         )
-        with torch.inference_mode():
+        with self._inference_context():
             with self._autocast_context():
                 warmup_out = self.model(warmup_in)
         torch.cuda.synchronize(self.device)
@@ -461,9 +485,11 @@ class GpuWorker:
 
             # H2D
             dev_in.copy_(batch.host_in, non_blocking=True)
+            if self.execution.channels_last:
+                dev_in = dev_in.contiguous(memory_format=torch.channels_last_3d)
 
             # Inference
-            with torch.inference_mode():
+            with self._inference_context():
                 with autocast_ctx:
                     out = self.model(dev_in)
 

--- a/src/aind_torch_utils/workflow.py
+++ b/src/aind_torch_utils/workflow.py
@@ -1,0 +1,127 @@
+"""Workflow: one object bundling a run's injected math, plus a name registry.
+
+After PRs 1-5 every workflow-owned decision -- preprocessing, the processor, its
+execution policy, and per-output merge/post/dtype -- is an injectable object. A
+:class:`Workflow` groups them so a recipe can hand the runtime a single value and the
+generic CLI can reach a named recipe via ``--workflow`` with no workflow-specific flags.
+
+Scope note (issue #25 §3.7): the registry is intentionally the *last* piece and stays
+deliberately small. It is provisional until a second real workflow has exercised these
+contracts; concrete recipes live under :mod:`aind_torch_utils.recipes`.
+"""
+from dataclasses import dataclass, field
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    runtime_checkable,
+)
+
+from aind_torch_utils.execution import ExecutionPolicy
+from aind_torch_utils.outputs import OutputSpec
+from aind_torch_utils.transforms import BlockPreprocessor
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import torch
+
+
+@runtime_checkable
+class BlockProcessor(Protocol):
+    """Tensor-in/tensor-out GPU processor: ``(B, Cin, Z, Y, X) -> (B, N, Z, Y, X)``.
+
+    Any ``nn.Module`` satisfies this; so does any callable hiding CUDA/CuPy/compiled
+    code. The runtime never assumes it is a neural network.
+    """
+
+    def __call__(self, batch: "torch.Tensor") -> "torch.Tensor":
+        """Run the processor on a batch of patches."""
+        ...
+
+
+# A factory that turns the opened output stores into per-output specs. Lets a recipe
+# defer spec construction until it sees the actual stores (e.g. to read their dtypes).
+OutputSpecFactory = Callable[[List[Any]], List[OutputSpec]]
+
+
+@dataclass
+class Workflow:
+    """A complete recipe: the processor plus the objects the runtime injects.
+
+    Attributes
+    ----------
+    processor : BlockProcessor
+        The model / GPU function run on each batch of patches.
+    preprocess : BlockPreprocessor, optional
+        Input-domain transform; ``None`` lets the runtime synthesize one from config.
+    outputs : list of OutputSpec, optional
+        Fixed per-output specs. Mutually exclusive with ``output_spec_factory``.
+    output_spec_factory : OutputSpecFactory, optional
+        Builds the specs from the opened output stores, when they are needed to
+        construct the specs. Mutually exclusive with ``outputs``.
+    execution : ExecutionPolicy
+        How the processor runs. Defaults to the plain policy (float32, no AMP); a
+        recipe overrides it to declare its processor's constraints.
+    """
+
+    processor: BlockProcessor
+    preprocess: Optional[BlockPreprocessor] = None
+    outputs: Optional[List[OutputSpec]] = None
+    output_spec_factory: Optional[OutputSpecFactory] = None
+    execution: ExecutionPolicy = field(default_factory=ExecutionPolicy)
+
+    def __post_init__(self):
+        if self.outputs is not None and self.output_spec_factory is not None:
+            raise ValueError(
+                "Set either outputs or output_spec_factory on a Workflow, not both."
+            )
+
+    def resolve_outputs(
+        self, output_stores: List[Any]
+    ) -> Optional[List[OutputSpec]]:
+        """Return per-output specs for these stores, or ``None`` to let run() default.
+
+        Fixed ``outputs`` win; otherwise the factory (if any) builds them from the
+        stores; otherwise ``None`` (the runtime synthesizes defaults from config).
+        """
+        if self.outputs is not None:
+            return self.outputs
+        if self.output_spec_factory is not None:
+            return self.output_spec_factory(output_stores)
+        return None
+
+
+class WorkflowRegistry:
+    """Registry mapping a workflow name to a builder ``build(params) -> Workflow``."""
+
+    _registry: Dict[str, Callable[[Dict[str, Any]], Workflow]] = {}
+
+    @classmethod
+    def register(cls, name: str) -> Callable:
+        """Decorator registering a workflow builder under ``name``."""
+
+        def decorator(
+            func: Callable[[Dict[str, Any]], Workflow]
+        ) -> Callable[[Dict[str, Any]], Workflow]:
+            cls._registry[name] = func
+            return func
+
+        return decorator
+
+    @classmethod
+    def build(cls, name: str, params: Optional[Dict[str, Any]] = None) -> Workflow:
+        """Build the named workflow from ``params`` (a plain dict of recipe args)."""
+        if name not in cls._registry:
+            available = list(cls._registry.keys())
+            raise KeyError(
+                f"Workflow '{name}' not found in registry. Available: {available}"
+            )
+        return cls._registry[name](params or {})
+
+    @classmethod
+    def list_workflows(cls) -> List[str]:
+        """List all registered workflow names."""
+        return list(cls._registry.keys())

--- a/src/aind_torch_utils/workflow.py
+++ b/src/aind_torch_utils/workflow.py
@@ -76,6 +76,13 @@ class Workflow:
     execution: Optional[ExecutionPolicy] = None
 
     def __post_init__(self):
+        """Validate the output specification configuration.
+
+        Raises
+        ------
+        ValueError
+            If both fixed outputs and an output specification factory are set.
+        """
         if self.outputs is not None and self.output_spec_factory is not None:
             raise ValueError(
                 "Set either outputs or output_spec_factory on a Workflow, not both."
@@ -108,6 +115,18 @@ class WorkflowRegistry:
         def decorator(
             func: Callable[[Dict[str, Any]], Workflow]
         ) -> Callable[[Dict[str, Any]], Workflow]:
+            """Store a workflow builder under the requested name.
+
+            Parameters
+            ----------
+            func : Callable
+                Workflow builder to register.
+
+            Returns
+            -------
+            Callable
+                The registered builder, unchanged.
+            """
             cls._registry[name] = func
             return func
 

--- a/src/aind_torch_utils/workflow.py
+++ b/src/aind_torch_utils/workflow.py
@@ -9,7 +9,7 @@ Scope note (issue #25 §3.7): the registry is intentionally the *last* piece and
 deliberately small. It is provisional until a second real workflow has exercised these
 contracts; concrete recipes live under :mod:`aind_torch_utils.recipes`.
 """
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -62,16 +62,18 @@ class Workflow:
     output_spec_factory : OutputSpecFactory, optional
         Builds the specs from the opened output stores, when they are needed to
         construct the specs. Mutually exclusive with ``outputs``.
-    execution : ExecutionPolicy
-        How the processor runs. Defaults to the plain policy (float32, no AMP); a
-        recipe overrides it to declare its processor's constraints.
+    execution : ExecutionPolicy, optional
+        How the processor runs. ``None`` (default) lets the runtime synthesize
+        the policy from config — the same rule as ``preprocess`` — so CLI/config
+        AMP and compile flags keep working; a recipe sets it to declare its
+        processor's constraints, which then override config.
     """
 
     processor: BlockProcessor
     preprocess: Optional[BlockPreprocessor] = None
     outputs: Optional[List[OutputSpec]] = None
     output_spec_factory: Optional[OutputSpecFactory] = None
-    execution: ExecutionPolicy = field(default_factory=ExecutionPolicy)
+    execution: Optional[ExecutionPolicy] = None
 
     def __post_init__(self):
         if self.outputs is not None and self.output_spec_factory is not None:

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -1,0 +1,92 @@
+"""Tests for the pluggable block accumulators and the default factory."""
+import numpy as np
+
+from aind_torch_utils.accumulators import (
+    BlockAccumulator,
+    LastWriteAccumulator,
+    MajorityVoteAccumulator,
+    MaxAccumulator,
+    SumAccumulator,
+    WeightedAverageAccumulator,
+    weighted_average_factory,
+)
+
+CTX = None  # accumulators do not use ctx
+
+
+def _patch(values):
+    """A (1, 1, N) float32 patch from a flat list."""
+    return np.asarray(values, dtype=np.float32).reshape(1, 1, -1)
+
+
+def test_max_accumulator_takes_elementwise_max_over_overlap():
+    acc = MaxAccumulator((1, 1, 4))
+    acc.add(_patch([1, 5, 1]), (0, 0, 0), (1, 1, 3))  # x0..2
+    acc.add(_patch([9, 2, 9]), (0, 0, 1), (1, 1, 3))  # x1..3
+    np.testing.assert_array_equal(acc.finalize().ravel(), [1, 9, 2, 9])
+
+
+def test_max_accumulator_uncovered_voxels_are_zero():
+    acc = MaxAccumulator((1, 1, 4))
+    acc.add(_patch([3, 3]), (0, 0, 0), (1, 1, 2))  # only x0,x1 covered
+    out = acc.finalize().ravel()
+    np.testing.assert_array_equal(out, [3, 3, 0, 0])
+
+
+def test_last_write_accumulator_last_patch_wins():
+    acc = LastWriteAccumulator((1, 1, 4))
+    acc.add(_patch([1, 1, 1]), (0, 0, 0), (1, 1, 3))
+    acc.add(_patch([7, 7, 7]), (0, 0, 1), (1, 1, 3))
+    # Overlap x1,x2 overwritten by the second patch.
+    np.testing.assert_array_equal(acc.finalize().ravel(), [1, 7, 7, 7])
+
+
+def test_sum_accumulator_adds_overlap():
+    acc = SumAccumulator((1, 1, 4))
+    acc.add(_patch([1, 1, 1]), (0, 0, 0), (1, 1, 3))
+    acc.add(_patch([10, 10, 10]), (0, 0, 1), (1, 1, 3))
+    np.testing.assert_array_equal(acc.finalize().ravel(), [1, 11, 11, 10])
+
+
+def test_majority_vote_picks_mode_and_breaks_ties_low():
+    acc = MajorityVoteAccumulator((1, 1, 3))
+    acc.add(_patch([1, 1, 2]), (0, 0, 0), (1, 1, 3))
+    acc.add(_patch([1, 2, 2]), (0, 0, 0), (1, 1, 3))
+    # x0: {1:2}; x1: {1:1, 2:1} tie -> smaller label; x2: {2:2}.
+    np.testing.assert_array_equal(acc.finalize().ravel(), [1, 1, 2])
+
+
+def test_majority_vote_empty_block_is_zeros():
+    acc = MajorityVoteAccumulator((1, 1, 2))
+    np.testing.assert_array_equal(acc.finalize().ravel(), [0, 0])
+
+
+def test_accumulators_track_count():
+    acc = SumAccumulator((1, 1, 2))
+    assert acc.count == 0
+    acc.add(_patch([1, 1]), (0, 0, 0), (1, 1, 2))
+    assert acc.count == 1
+
+
+def test_weighted_average_factory_builds_default_accumulator():
+    factory = weighted_average_factory(
+        eps=1e-6, overlap=4, seam_mode="trim", trim_voxels=2, min_blend_weight=0.05
+    )
+    acc = factory((2, 2, 2), CTX)
+    assert isinstance(acc, WeightedAverageAccumulator)
+    # a single block-sized patch (no trim at borders) round-trips through finalize
+    patch = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+    acc.total = 1
+    acc.add(patch, (0, 0, 0), (2, 2, 2))
+    np.testing.assert_allclose(acc.finalize(), patch)
+
+
+def test_accumulators_satisfy_protocol():
+    for acc in (
+        MaxAccumulator((1, 1, 1)),
+        LastWriteAccumulator((1, 1, 1)),
+        SumAccumulator((1, 1, 1)),
+        MajorityVoteAccumulator((1, 1, 1)),
+        WeightedAverageAccumulator((1, 1, 1), 1e-6, 0, "trim", 0, 0.05),
+    ):
+        assert isinstance(acc, BlockAccumulator)

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -61,11 +61,22 @@ def test_majority_vote_empty_block_is_zeros():
     np.testing.assert_array_equal(acc.finalize().ravel(), [0, 0])
 
 
-def test_accumulators_track_count():
-    acc = SumAccumulator((1, 1, 2))
-    assert acc.count == 0
-    acc.add(_patch([1, 1]), (0, 0, 0), (1, 1, 2))
-    assert acc.count == 1
+def test_majority_vote_uncovered_voxels_are_background():
+    """Voxels no patch votes on finalize to 0, not the smallest seen label."""
+    acc = MajorityVoteAccumulator((1, 1, 4))
+    # Only x0..x1 covered, with foreground labels {3, 5} (no 0 anywhere).
+    acc.add(_patch([3, 5]), (0, 0, 0), (1, 1, 2))
+    np.testing.assert_array_equal(acc.finalize().ravel(), [3, 5, 0, 0])
+
+
+def test_majority_vote_ignores_nan_and_shares_vote_planes():
+    """NaN is skipped (not a label), and repeated adds of the same label reuse
+    one vote plane instead of allocating a new one per add."""
+    acc = MajorityVoteAccumulator((1, 1, 2))
+    acc.add(_patch([np.nan, 7]), (0, 0, 0), (1, 1, 2))
+    acc.add(_patch([np.nan, 7]), (0, 0, 0), (1, 1, 2))
+    assert len(acc.votes) == 1  # one plane for label 7, none for NaN
+    np.testing.assert_array_equal(acc.finalize().ravel(), [0, 7])
 
 
 def test_weighted_average_factory_builds_default_accumulator():
@@ -76,7 +87,6 @@ def test_weighted_average_factory_builds_default_accumulator():
     assert isinstance(acc, WeightedAverageAccumulator)
     # a single block-sized patch (no trim at borders) round-trips through finalize
     patch = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
-    acc.total = 1
     acc.add(patch, (0, 0, 0), (2, 2, 2))
     np.testing.assert_allclose(acc.finalize(), patch)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,86 @@
+"""Tests for BlockContext construction and writer-side reconstruction."""
+from aind_torch_utils.context import BlockContext
+
+
+class _FakePreds:
+    """Just the fields BlockContext.from_preds reads."""
+
+    def __init__(self, block_idx, block_bbox, halo_left, acc_shape):
+        self.block_idx = block_idx
+        self.block_bbox = block_bbox
+        self.halo_left = halo_left
+        self.acc_shape = acc_shape
+
+
+def test_from_block_derives_halo_left():
+    core = (slice(40, 60), slice(40, 60), slice(40, 60))
+    expanded = (slice(32, 68), slice(32, 68), slice(32, 68))
+
+    ctx = BlockContext.from_block(
+        block_idx=(1, 1, 1),
+        core_bbox=core,
+        expanded_bbox=expanded,
+        full_shape=(100, 100, 100),
+        t_idx=0,
+        c_idx=0,
+    )
+
+    assert ctx.halo_left == (8, 8, 8)
+    assert ctx.core_bbox == core
+    assert ctx.expanded_bbox == expanded
+    assert ctx.full_shape == (100, 100, 100)
+
+
+def test_from_preds_reconstructs_expanded_bbox():
+    core = (slice(40, 60), slice(40, 60), slice(40, 60))
+    preds = _FakePreds(
+        block_idx=(1, 1, 1),
+        block_bbox=core,
+        halo_left=(8, 8, 8),
+        acc_shape=(36, 36, 36),  # 20 core + 8 halo on each side
+    )
+
+    ctx = BlockContext.from_preds(preds, full_shape=(100, 100, 100), t_idx=0, c_idx=0)
+
+    assert ctx.expanded_bbox == (slice(32, 68), slice(32, 68), slice(32, 68))
+    assert ctx.core_bbox == core
+    assert ctx.halo_left == (8, 8, 8)
+
+
+def test_from_block_and_from_preds_round_trip():
+    """A context built in prep equals the one reconstructed in the writer."""
+    core = (slice(40, 60), slice(40, 60), slice(40, 60))
+    expanded = (slice(32, 68), slice(32, 68), slice(32, 68))
+    full = (100, 100, 100)
+
+    prep_ctx = BlockContext.from_block(
+        block_idx=(1, 1, 1),
+        core_bbox=core,
+        expanded_bbox=expanded,
+        full_shape=full,
+        t_idx=2,
+        c_idx=3,
+    )
+
+    acc_shape = tuple(e.stop - e.start for e in expanded)
+    preds = _FakePreds((1, 1, 1), core, prep_ctx.halo_left, acc_shape)
+    writer_ctx = BlockContext.from_preds(preds, full_shape=full, t_idx=2, c_idx=3)
+
+    assert prep_ctx == writer_ctx
+
+
+def test_from_preds_handles_clipped_border_halo():
+    """At a volume border the halo is one-sided; reconstruction must still match."""
+    # Core touches z=0: left halo clipped to 0, right halo 8 -> acc_shape z = 28.
+    core = (slice(0, 20), slice(0, 20), slice(0, 20))
+    preds = _FakePreds(
+        block_idx=(0, 0, 0),
+        block_bbox=core,
+        halo_left=(0, 0, 0),
+        acc_shape=(28, 28, 28),
+    )
+
+    ctx = BlockContext.from_preds(preds, full_shape=(200, 200, 200), t_idx=0, c_idx=0)
+
+    assert ctx.expanded_bbox == (slice(0, 28), slice(0, 28), slice(0, 28))
+    assert ctx.halo_left == (0, 0, 0)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,15 +1,5 @@
-"""Tests for BlockContext construction and writer-side reconstruction."""
+"""Tests for BlockContext construction."""
 from aind_torch_utils.context import BlockContext
-
-
-class _FakePreds:
-    """Just the fields BlockContext.from_preds reads."""
-
-    def __init__(self, block_idx, block_bbox, halo_left, acc_shape):
-        self.block_idx = block_idx
-        self.block_bbox = block_bbox
-        self.halo_left = halo_left
-        self.acc_shape = acc_shape
 
 
 def test_from_block_derives_halo_left():
@@ -31,56 +21,19 @@ def test_from_block_derives_halo_left():
     assert ctx.full_shape == (100, 100, 100)
 
 
-def test_from_preds_reconstructs_expanded_bbox():
-    core = (slice(40, 60), slice(40, 60), slice(40, 60))
-    preds = _FakePreds(
-        block_idx=(1, 1, 1),
-        block_bbox=core,
-        halo_left=(8, 8, 8),
-        acc_shape=(36, 36, 36),  # 20 core + 8 halo on each side
-    )
+def test_from_block_clipped_border_halo():
+    """At a volume border the halo is one-sided; halo_left must reflect it."""
+    core = (slice(0, 20), slice(0, 20), slice(0, 20))
+    expanded = (slice(0, 28), slice(0, 28), slice(0, 28))
 
-    ctx = BlockContext.from_preds(preds, full_shape=(100, 100, 100), t_idx=0, c_idx=0)
-
-    assert ctx.expanded_bbox == (slice(32, 68), slice(32, 68), slice(32, 68))
-    assert ctx.core_bbox == core
-    assert ctx.halo_left == (8, 8, 8)
-
-
-def test_from_block_and_from_preds_round_trip():
-    """A context built in prep equals the one reconstructed in the writer."""
-    core = (slice(40, 60), slice(40, 60), slice(40, 60))
-    expanded = (slice(32, 68), slice(32, 68), slice(32, 68))
-    full = (100, 100, 100)
-
-    prep_ctx = BlockContext.from_block(
-        block_idx=(1, 1, 1),
+    ctx = BlockContext.from_block(
+        block_idx=(0, 0, 0),
         core_bbox=core,
         expanded_bbox=expanded,
-        full_shape=full,
-        t_idx=2,
-        c_idx=3,
+        full_shape=(200, 200, 200),
+        t_idx=0,
+        c_idx=0,
     )
 
-    acc_shape = tuple(e.stop - e.start for e in expanded)
-    preds = _FakePreds((1, 1, 1), core, prep_ctx.halo_left, acc_shape)
-    writer_ctx = BlockContext.from_preds(preds, full_shape=full, t_idx=2, c_idx=3)
-
-    assert prep_ctx == writer_ctx
-
-
-def test_from_preds_handles_clipped_border_halo():
-    """At a volume border the halo is one-sided; reconstruction must still match."""
-    # Core touches z=0: left halo clipped to 0, right halo 8 -> acc_shape z = 28.
-    core = (slice(0, 20), slice(0, 20), slice(0, 20))
-    preds = _FakePreds(
-        block_idx=(0, 0, 0),
-        block_bbox=core,
-        halo_left=(0, 0, 0),
-        acc_shape=(28, 28, 28),
-    )
-
-    ctx = BlockContext.from_preds(preds, full_shape=(200, 200, 200), t_idx=0, c_idx=0)
-
-    assert ctx.expanded_bbox == (slice(0, 28), slice(0, 28), slice(0, 28))
     assert ctx.halo_left == (0, 0, 0)
+    assert ctx.expanded_bbox == expanded

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,33 @@
+"""Tests for ExecutionPolicy and its synthesis from config."""
+import torch
+
+from aind_torch_utils.execution import ExecutionPolicy
+
+
+def test_defaults():
+    p = ExecutionPolicy()
+    assert p.input_dtype == torch.float32
+    assert p.autocast is False
+    assert p.inference_mode is True
+    assert p.compile is False
+    assert p.channels_last is False
+
+
+def test_from_config_amp_on():
+    p = ExecutionPolicy.from_config(
+        amp=True, use_compile=True, compile_mode="reduce-overhead", compile_dynamic=None
+    )
+    assert p.input_dtype == torch.float16
+    assert p.autocast is True
+    assert p.compile is True
+    assert p.compile_mode == "reduce-overhead"
+
+
+def test_from_config_amp_off():
+    p = ExecutionPolicy.from_config(
+        amp=False, use_compile=False, compile_mode="default", compile_dynamic=False
+    )
+    assert p.input_dtype == torch.float32
+    assert p.autocast is False
+    assert p.compile is False
+    assert p.compile_dynamic is False

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,0 +1,48 @@
+"""Tests for OutputSpec defaults and output-domain post-processors."""
+import numpy as np
+import pytest
+
+from aind_torch_utils.accumulators import weighted_average_factory
+from aind_torch_utils.outputs import (
+    BlockPostProcessor,
+    OutputSpec,
+    Threshold,
+    ThresholdThenOpen,
+)
+
+CTX = None
+
+
+def _factory():
+    return weighted_average_factory(1e-6, 4, "trim", 2, 0.05)
+
+
+def test_output_spec_defaults():
+    spec = OutputSpec(store=object(), accumulator_factory=_factory())
+    assert spec.postprocess is None
+    assert spec.invert is False
+
+
+def test_threshold_binarizes():
+    block = np.array([[[-1.0, 0.0, 0.5, 2.0]]], dtype=np.float32)
+    out = Threshold(thresh=0.0)(block, CTX)
+    np.testing.assert_array_equal(out.ravel(), [0, 0, 1, 1])
+    assert isinstance(Threshold(), BlockPostProcessor)
+
+
+def test_threshold_custom_levels():
+    block = np.array([[[1.0, 5.0]]], dtype=np.float32)
+    out = Threshold(thresh=3.0, above=255.0, below=7.0)(block, CTX)
+    np.testing.assert_array_equal(out.ravel(), [7, 255])
+
+
+def test_threshold_then_open_removes_speckle():
+    pytest.importorskip("scipy")
+    # A 1-voxel speckle surrounded by background is removed by opening; a solid
+    # block survives.
+    block = np.zeros((5, 5, 5), dtype=np.float32)
+    block[0, 0, 0] = 10.0  # isolated speckle -> opened away
+    block[1:4, 1:4, 1:4] = 10.0  # solid cube -> (mostly) survives
+    out = ThresholdThenOpen(thresh=0.0, open_iters=1)(block, CTX)
+    assert out[0, 0, 0] == 0.0
+    assert out[2, 2, 2] == 1.0

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -150,6 +150,20 @@ def _run_test_logic(input_store, output_store, metrics_json, devices, model):
     )
 
 
+@pytest.mark.parametrize(
+    ("t_idx", "c_idx"),
+    [(-1, 0), (1, 0), (0, -1), (0, 1)],
+)
+def test_run_rejects_invalid_time_or_channel_index(t_idx, c_idx):
+    """Invalid store indices raise even when Python assertions are disabled."""
+    input_store = unittest.mock.Mock()
+    input_store.domain.shape = (1, 1, 32, 32, 32)
+    cfg = InferenceConfig(t_idx=t_idx, c_idx=c_idx, devices=["cpu"])
+
+    with pytest.raises(ValueError, match="Invalid t/c indices"):
+        run(DummyModel(), input_store, object(), cfg)
+
+
 @pytest.fixture
 def multi_output_data(tmp_path):
     """Two output stores (float32) matching the 32³ input volume."""

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -8,7 +8,8 @@ from torch import nn
 
 from aind_torch_utils.config import InferenceConfig
 from aind_torch_utils.models import SharedEncoderModel
-from aind_torch_utils.run import run
+from aind_torch_utils.outputs import OutputSpec
+from aind_torch_utils.run import _resolve_output_specs, run
 
 
 class DummyModel(nn.Module):
@@ -212,6 +213,39 @@ def test_run_multi_output_pipeline(multi_output_data, tmp_path):
     out0 = out_stores[0].read().result().astype(np.float32)
     out1 = out_stores[1].read().result().astype(np.float32)
     np.testing.assert_allclose(out0, out1, rtol=1e-4)
+
+
+def test_resolve_output_specs_synthesizes_from_store():
+    cfg = InferenceConfig(devices=["cpu"], output_denormalize=True)
+    specs = _resolve_output_specs(object(), None, cfg)
+    assert len(specs) == 1
+    assert specs[0].invert is True  # driven by output_denormalize
+    assert specs[0].postprocess is None
+    assert specs[0].accumulator_factory is not None
+
+
+def test_resolve_output_specs_list_store():
+    cfg = InferenceConfig(devices=["cpu"], output_denormalize=False)
+    specs = _resolve_output_specs([object(), object()], None, cfg)
+    assert len(specs) == 2
+    assert all(s.invert is False for s in specs)
+
+
+def test_resolve_output_specs_passthrough_explicit():
+    cfg = InferenceConfig(devices=["cpu"])
+    factory = object()
+    explicit = [OutputSpec(store=object(), accumulator_factory=factory)]
+    assert _resolve_output_specs(None, explicit, cfg) is explicit
+
+
+def test_resolve_output_specs_rejects_both_and_neither():
+    cfg = InferenceConfig(devices=["cpu"])
+    with pytest.raises(ValueError, match="not both"):
+        _resolve_output_specs(object(), [OutputSpec(object(), object())], cfg)
+    with pytest.raises(ValueError, match="Provide output_store"):
+        _resolve_output_specs(None, None, cfg)
+    with pytest.raises(ValueError, match="non-empty"):
+        _resolve_output_specs(None, [], cfg)
 
 
 def test_shared_encoder_model_forward():

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -7,9 +7,11 @@ import torch
 from torch import nn
 
 from aind_torch_utils.config import InferenceConfig
+from aind_torch_utils.execution import ExecutionPolicy
 from aind_torch_utils.models import SharedEncoderModel
 from aind_torch_utils.outputs import OutputSpec
-from aind_torch_utils.run import _resolve_output_specs, run
+from aind_torch_utils.run import _resolve_output_specs, run, run_workflow
+from aind_torch_utils.workflow import Workflow, WorkflowRegistry
 
 
 class DummyModel(nn.Module):
@@ -246,6 +248,53 @@ def test_resolve_output_specs_rejects_both_and_neither():
         _resolve_output_specs(None, None, cfg)
     with pytest.raises(ValueError, match="non-empty"):
         _resolve_output_specs(None, [], cfg)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for GPU pipeline"
+)
+def test_run_workflow_end_to_end(temp_dir, dummy_data):
+    """A registered Workflow (identity processor, no normalization) runs through
+    run_workflow and reproduces the input."""
+    input_store, output_store = dummy_data
+
+    @WorkflowRegistry.register("test-identity-workflow")
+    def _build(params):
+        return Workflow(
+            processor=DummyModel(),
+            preprocess=None,  # run() synthesizes from cfg (normalize=False)
+            execution=ExecutionPolicy.from_config(
+                amp=False, use_compile=False, compile_mode="default",
+                compile_dynamic=None,
+            ),
+        )
+
+    cfg = InferenceConfig(
+        patch=(16, 16, 16),
+        overlap=4,
+        trim_voxels=2,
+        seam_mode="trim",
+        block=(32, 32, 32),
+        batch_size=4,
+        devices=["cuda:0"],
+        amp=False,
+        max_inflight_batches=10,
+        normalize=False,
+    )
+
+    workflow = WorkflowRegistry.build("test-identity-workflow")
+    run_workflow(
+        workflow,
+        input_store,
+        output_store,
+        cfg,
+        metrics_json=str(temp_dir / "wf_metrics.json"),
+        metrics_interval=0.1,
+    )
+
+    np.testing.assert_array_equal(
+        input_store.read().result(), output_store.read().result()
+    )
 
 
 def test_shared_encoder_model_forward():

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -10,7 +10,12 @@ from aind_torch_utils.config import InferenceConfig
 from aind_torch_utils.execution import ExecutionPolicy
 from aind_torch_utils.models import SharedEncoderModel
 from aind_torch_utils.outputs import OutputSpec
-from aind_torch_utils.run import _resolve_output_specs, run, run_workflow
+from aind_torch_utils.run import (
+    _resolve_output_specs,
+    _validate_inversion,
+    run,
+    run_workflow,
+)
 from aind_torch_utils.workflow import Workflow, WorkflowRegistry
 
 
@@ -248,6 +253,69 @@ def test_resolve_output_specs_rejects_both_and_neither():
         _resolve_output_specs(None, None, cfg)
     with pytest.raises(ValueError, match="non-empty"):
         _resolve_output_specs(None, [], cfg)
+
+
+def test_resolve_output_specs_rejects_none_store():
+    """A None store must fail here, not as an AttributeError in a writer thread."""
+    cfg = InferenceConfig(devices=["cpu"])
+    specs = [OutputSpec(store=None, accumulator_factory=object())]
+    with pytest.raises(ValueError, match="store=None"):
+        _resolve_output_specs(None, specs, cfg)
+
+
+def test_validate_inversion_rejects_invert_without_inverse():
+    """invert=True + forward-only preprocess must error, not silently skip."""
+
+    class _ForwardOnly:
+        def forward(self, block, ctx):
+            return block, None
+
+    specs = [
+        OutputSpec(store=object(), accumulator_factory=object(), invert=True)
+    ]
+    with pytest.raises(ValueError, match="defines no inverse"):
+        _validate_inversion(_ForwardOnly(), specs)
+    # invert=False everywhere -> a forward-only preprocess is fine.
+    _validate_inversion(
+        _ForwardOnly(),
+        [OutputSpec(store=object(), accumulator_factory=object(), invert=False)],
+    )
+
+
+def test_validate_inversion_rejects_unknown_stage():
+    """A typo'd inverse_stage must error, not silently disable inversion."""
+
+    class _TypoStage:
+        inverse_stage = "after-finalize"  # hyphen typo
+
+        def forward(self, block, ctx):
+            return block, None
+
+        def inverse(self, block, state, ctx):
+            return block
+
+    specs = [
+        OutputSpec(store=object(), accumulator_factory=object(), invert=True)
+    ]
+    with pytest.raises(ValueError, match="Unknown inverse_stage"):
+        _validate_inversion(_TypoStage(), specs)
+
+
+def test_validate_inversion_defaults_missing_stage():
+    """A duck-typed invertible transform without inverse_stage is accepted
+    (the writer defaults it to after_finalize)."""
+
+    class _NoStage:
+        def forward(self, block, ctx):
+            return block, None
+
+        def inverse(self, block, state, ctx):
+            return block
+
+    specs = [
+        OutputSpec(store=object(), accumulator_factory=object(), invert=True)
+    ]
+    _validate_inversion(_NoStage(), specs)  # must not raise
 
 
 @pytest.mark.skipif(

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -49,3 +49,16 @@ def test_main_requires_exactly_one_of_model_or_workflow():
                 "--workflow", "w",
             ]
         )
+
+
+def test_main_rejects_weights_with_workflow():
+    """--weights would be silently ignored in workflow mode; refuse it instead."""
+    with pytest.raises(SystemExit, match="--weights only applies"):
+        main(
+            [
+                "--in-spec", "in.json",
+                "--out-spec", "out.json",
+                "--workflow", "w",
+                "--weights", "w.pt",
+            ]
+        )

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1,4 +1,6 @@
-from aind_torch_utils.run import _parse_args
+import pytest
+
+from aind_torch_utils.run import _parse_args, main
 
 
 def _minimal_required_args(extra=None):
@@ -23,3 +25,27 @@ def test_cli_output_denormalize_default_enabled():
 def test_cli_output_denormalize_can_be_disabled():
     args = _parse_args(_minimal_required_args(["--no-output-denormalize"]))
     assert args.no_output_denormalize is True
+
+
+def test_cli_workflow_flag_parsed():
+    args = _parse_args(
+        ["--in-spec", "in.json", "--out-spec", "out.json", "--workflow", "seg"]
+    )
+    assert args.workflow == "seg"
+    assert args.model_type is None
+
+
+def test_main_requires_exactly_one_of_model_or_workflow():
+    # Neither --model-type nor --workflow -> fail fast before any I/O.
+    with pytest.raises(SystemExit):
+        main(["--in-spec", "in.json", "--out-spec", "out.json"])
+    # Both -> also rejected.
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "--in-spec", "in.json",
+                "--out-spec", "out.json",
+                "--model-type", "d",
+                "--workflow", "w",
+            ]
+        )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,148 @@
+"""Tests for block preprocessors / invertible transforms.
+
+Besides the behavioral checks, `test_*_matches_legacy_*` lock the arithmetic to the
+exact operations PrepWorker/WriterWorker used to inline, so PR2b can swap them in
+without changing any existing run's output.
+"""
+import numpy as np
+import pytest
+
+from aind_torch_utils.transforms import (
+    Clip,
+    GlobalNormalizer,
+    IdentityTransform,
+    PercentileNormalizer,
+    Sequential,
+    from_config,
+    is_invertible,
+)
+
+# ctx is unused by every transform here; None proves it.
+CTX = None
+
+
+def _rand_block(seed=0):
+    rng = np.random.default_rng(seed)
+    return (rng.random((8, 8, 8), dtype=np.float32) * 1000.0).astype(np.float32)
+
+
+def test_percentile_normalizer_matches_legacy_forward_and_inverse():
+    lower, upper, eps = 0.5, 99.9, 1e-6
+    block = _rand_block()
+
+    # Legacy prep math (in place on a float32 copy).
+    legacy = block.copy()
+    mn, mx = np.percentile(legacy, [lower, upper])
+    scale = max(mx - mn, eps)
+    legacy -= mn
+    legacy /= scale
+
+    norm = PercentileNormalizer(lower, upper, eps)
+    out, state = norm.forward(block.copy(), CTX)
+    assert np.array_equal(out, legacy)
+    assert state == (float(mn), float(mx))
+
+    # Legacy writer denorm.
+    dscale = max(state[1] - state[0], eps)
+    legacy_inv = (out * np.float32(dscale) + np.float32(state[0])).astype(np.float32)
+    assert np.array_equal(norm.inverse(out, state, CTX), legacy_inv)
+
+
+def test_percentile_normalizer_round_trips():
+    block = _rand_block(1)
+    norm = PercentileNormalizer(0.0, 100.0)  # full range -> exact affine
+    out, state = norm.forward(block.copy(), CTX)
+    recovered = norm.inverse(out, state, CTX)
+    np.testing.assert_allclose(recovered, block, rtol=1e-4, atol=1e-2)
+
+
+def test_global_normalizer_matches_legacy():
+    lower, upper, eps = 10.0, 900.0, 1e-6
+    block = _rand_block(2)
+
+    scale = max(upper - lower, eps)
+    legacy = np.clip(block, lower, upper)
+    legacy = ((legacy - lower) / scale).astype(np.float32)
+
+    norm = GlobalNormalizer(lower, upper, eps)
+    out, state = norm.forward(block.copy(), CTX)
+    assert np.array_equal(out, legacy)
+    assert state == (lower, upper)
+    assert out.dtype == np.float32
+
+
+def test_identity_transform_is_noop():
+    block = _rand_block(3)
+    ident = IdentityTransform()
+    out, state = ident.forward(block, CTX)
+    assert out is block
+    assert state is None
+    assert np.array_equal(ident.inverse(block, state, CTX), block)
+
+
+def test_clip_is_non_invertible_and_clips():
+    block = _rand_block(4)
+    clip = Clip(100.0, 200.0)
+    out, state = clip.forward(block, CTX)
+    assert state is None
+    assert not is_invertible(clip)
+    assert out.min() >= 100.0 and out.max() <= 200.0
+
+
+def test_sequential_forward_composes_and_inverse_reverses():
+    block = _rand_block(5)
+    seq = Sequential([PercentileNormalizer(0.0, 100.0), Clip(0.0, 1.0)])
+
+    out, state = seq.forward(block.copy(), CTX)
+    # Composite state is one entry per member (Clip contributes None).
+    assert isinstance(state, tuple) and len(state) == 2
+    assert state[1] is None
+    assert out.min() >= 0.0 and out.max() <= 1.0
+
+    # inverse skips the non-invertible Clip and undoes the normalizer.
+    recovered = seq.inverse(out, state, CTX)
+    # Values were within [0,1] after normalization (full-range percentiles), so the
+    # Clip was a no-op here and the affine inverse recovers the original block.
+    np.testing.assert_allclose(recovered, block, rtol=1e-4, atol=1e-2)
+
+
+def test_sequential_inverse_stage_agreement():
+    seq = Sequential([PercentileNormalizer(0.0, 100.0), Clip(0.0, 1.0)])
+    assert seq.inverse_stage == "after_finalize"
+
+    class _Weird:
+        inverse_stage = "before_accumulate"
+
+        def forward(self, b, c):
+            return b, None
+
+        def inverse(self, b, s, c):
+            return b
+
+    with pytest.raises(ValueError, match="disagree on inverse_stage"):
+        _ = Sequential([PercentileNormalizer(0.0, 100.0), _Weird()]).inverse_stage
+
+
+@pytest.mark.parametrize(
+    "normalize,expected_type",
+    [
+        ("percentile", PercentileNormalizer),
+        ("global", GlobalNormalizer),
+        (False, IdentityTransform),
+    ],
+)
+def test_from_config_selects_transform(normalize, expected_type):
+    t = from_config(normalize, 0.5, 99.9, 1e-6, clip_norm=False)
+    assert isinstance(t, expected_type)
+
+
+def test_from_config_wraps_clip_in_sequential():
+    t = from_config("percentile", 0.5, 99.9, 1e-6, clip_norm=True)
+    assert isinstance(t, Sequential)
+    assert isinstance(t.steps[0], PercentileNormalizer)
+    assert isinstance(t.steps[1], Clip)
+    assert (t.steps[1].lo, t.steps[1].hi) == (0.0, 1.0)
+
+    t2 = from_config("global", 10.0, 900.0, 1e-6, clip_norm=(0.1, 0.9))
+    assert isinstance(t2, Sequential)
+    assert (t2.steps[1].lo, t2.steps[1].hi) == (0.1, 0.9)

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -49,6 +49,64 @@ def _drain(prep_q):
     return batches
 
 
+class _FakeResult:
+    def result(self):
+        return None
+
+
+class _FakeSlice:
+    def __init__(self, store):
+        self._store = store
+
+    def write(self, arr):
+        self._store.written = np.asarray(arr)
+        return _FakeResult()
+
+
+class _FakeDtype:
+    def __init__(self, np_dtype):
+        self.numpy_dtype = np.dtype(np_dtype)
+
+
+class _FakeStore:
+    """Minimal TensorStore stand-in: records the last array written."""
+
+    def __init__(self, np_dtype=np.float32):
+        self._dtype = _FakeDtype(np_dtype)
+        self.written = None
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    def __getitem__(self, key):
+        return _FakeSlice(self)
+
+
+def _single_patch_preds(host_out, transform_state):
+    """A Preds for a 2x2x2 single-patch block that completes on arrival."""
+    return Preds(
+        block_idx=(0, 0, 0),
+        block_bbox=(slice(0, 2), slice(0, 2), slice(0, 2)),
+        linear_k=0,
+        starts_in_block=[(0, 0, 0)],
+        host_out=host_out,
+        valid_sizes=[(2, 2, 2)],
+        transform_state=transform_state,
+        total_patches_in_block=1,
+        acc_shape=(2, 2, 2),
+        halo_left=(0, 0, 0),
+        ready_event=None,
+    )
+
+
+def _run_writer_once(cfg, store, preds):
+    write_q: "queue.Queue[Optional[Preds]]" = queue.Queue()
+    write_q.put(preds)
+    write_q.put(None)  # sentinel closes the writer loop
+    WriterWorker(cfg=cfg, writers=[store], write_q=write_q).run(threading.Event())
+
+
 def test_prep_worker_pads_tail_batch_to_constant_shape_when_compiling():
     """With torch.compile, every batch must have exactly batch_size rows so
     the compiled model never sees a varying input shape; padded rows must be
@@ -68,7 +126,9 @@ def test_prep_worker_pads_tail_batch_to_constant_shape_when_compiling():
         n_real = len(b.starts_in_block)
         assert 0 < n_real <= cfg.batch_size
         assert len(b.valid_sizes) == n_real
-        assert len(b.per_block_minmax) == n_real
+        # transform_state is per-block (one affine pair), not per-patch. With
+        # normalize=False the identity state is (0.0, 1.0).
+        assert b.transform_state == (0.0, 1.0)
         total_real += n_real
         if n_real < cfg.batch_size:
             saw_partial = True
@@ -115,7 +175,7 @@ def test_writer_raises_on_mismatched_output_channels_and_writers():
         starts_in_block=[(0, 0, 0)],
         host_out=torch.zeros((1, 2, 2, 2, 2), dtype=torch.float32),
         valid_sizes=[(2, 2, 2)],
-        per_block_minmax=[(0.0, 1.0)],
+        transform_state=(0.0, 1.0),
         total_patches_in_block=1,
         acc_shape=(2, 2, 2),
         halo_left=(0, 0, 0),
@@ -126,6 +186,34 @@ def test_writer_raises_on_mismatched_output_channels_and_writers():
 
     with pytest.raises(ValueError, match="Mismatch between model output channels"):
         worker.run(stop_event=threading.Event())
+
+
+def test_writer_applies_block_level_transform_state_inverse():
+    """output_denormalize=True applies the affine inverse from transform_state."""
+    cfg = InferenceConfig(devices=["cpu"], output_denormalize=True)
+    store = _FakeStore(np.float32)
+
+    # Normalized output 0.5 with state (mn, mx) = (10, 20) -> 0.5 * 10 + 10 = 15.
+    host_out = torch.full((1, 1, 2, 2, 2), 0.5, dtype=torch.float32)
+    _run_writer_once(
+        cfg, store, _single_patch_preds(host_out, transform_state=(10.0, 20.0))
+    )
+
+    assert store.written is not None
+    assert store.written.shape == (2, 2, 2)
+    np.testing.assert_allclose(store.written, 15.0)
+
+
+def test_writer_ignores_transform_state_when_denorm_disabled():
+    """output_denormalize=False writes outputs as-is and never reads transform_state."""
+    cfg = InferenceConfig(devices=["cpu"], output_denormalize=False)
+    store = _FakeStore(np.float32)
+
+    host_out = torch.full((1, 1, 2, 2, 2), 0.5, dtype=torch.float32)
+    # transform_state=None proves the opaque blob is not inspected on this path.
+    _run_writer_once(cfg, store, _single_patch_preds(host_out, transform_state=None))
+
+    np.testing.assert_allclose(store.written, 0.5)
 
 
 def _make_compile_worker():

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -8,7 +8,19 @@ import tensorstore as ts
 import torch
 
 from aind_torch_utils.config import InferenceConfig
+from aind_torch_utils.transforms import (
+    GlobalNormalizer,
+    IdentityTransform,
+    from_config,
+)
 from aind_torch_utils.workers import GpuWorker, Preds, PrepWorker, WriterWorker
+
+
+def _default_preprocess(cfg):
+    """The same transform run() synthesizes from config."""
+    return from_config(
+        cfg.normalize, cfg.norm_lower, cfg.norm_upper, cfg.eps, cfg.clip_norm
+    )
 
 
 def _make_input_store(shape):
@@ -100,11 +112,17 @@ def _single_patch_preds(host_out, transform_state):
     )
 
 
-def _run_writer_once(cfg, store, preds):
+def _run_writer_once(cfg, store, preds, preprocess, full_shape=(2, 2, 2)):
     write_q: "queue.Queue[Optional[Preds]]" = queue.Queue()
     write_q.put(preds)
     write_q.put(None)  # sentinel closes the writer loop
-    WriterWorker(cfg=cfg, writers=[store], write_q=write_q).run(threading.Event())
+    WriterWorker(
+        cfg=cfg,
+        writers=[store],
+        write_q=write_q,
+        preprocess=preprocess,
+        full_shape=full_shape,
+    ).run(threading.Event())
 
 
 def test_prep_worker_pads_tail_batch_to_constant_shape_when_compiling():
@@ -114,7 +132,9 @@ def test_prep_worker_pads_tail_batch_to_constant_shape_when_compiling():
     store = _make_input_store((1, 1, 32, 32, 32))
     cfg = _prep_cfg(use_compile=True)
     prep_q = queue.Queue()
-    PrepWorker(cfg, store, prep_q, cfg.patch).run(threading.Event())
+    PrepWorker(
+        cfg, store, prep_q, cfg.patch, _default_preprocess(cfg)
+    ).run(threading.Event())
 
     batches = _drain(prep_q)
     assert batches
@@ -126,9 +146,9 @@ def test_prep_worker_pads_tail_batch_to_constant_shape_when_compiling():
         n_real = len(b.starts_in_block)
         assert 0 < n_real <= cfg.batch_size
         assert len(b.valid_sizes) == n_real
-        # transform_state is per-block (one affine pair), not per-patch. With
-        # normalize=False the identity state is (0.0, 1.0).
-        assert b.transform_state == (0.0, 1.0)
+        # transform_state is per-block (produced by the injected transform), not
+        # per-patch. With normalize=False (IdentityTransform) there is no state.
+        assert b.transform_state is None
         total_real += n_real
         if n_real < cfg.batch_size:
             saw_partial = True
@@ -146,7 +166,9 @@ def test_prep_worker_does_not_pad_in_eager_mode():
     store = _make_input_store((1, 1, 32, 32, 32))
     cfg = _prep_cfg(use_compile=False)
     prep_q = queue.Queue()
-    PrepWorker(cfg, store, prep_q, cfg.patch).run(threading.Event())
+    PrepWorker(
+        cfg, store, prep_q, cfg.patch, _default_preprocess(cfg)
+    ).run(threading.Event())
 
     batches = _drain(prep_q)
     assert batches
@@ -166,7 +188,13 @@ def test_writer_raises_on_mismatched_output_channels_and_writers():
     write_q: "queue.Queue[Optional[Preds]]" = queue.Queue()
 
     # Single writer, but model output has N=2 channels.
-    worker = WriterWorker(cfg=cfg, writers=[object()], write_q=write_q)
+    worker = WriterWorker(
+        cfg=cfg,
+        writers=[object()],
+        write_q=write_q,
+        preprocess=IdentityTransform(),
+        full_shape=(2, 2, 2),
+    )
 
     preds = Preds(
         block_idx=(0, 0, 0),
@@ -189,14 +217,19 @@ def test_writer_raises_on_mismatched_output_channels_and_writers():
 
 
 def test_writer_applies_block_level_transform_state_inverse():
-    """output_denormalize=True applies the affine inverse from transform_state."""
+    """output_denormalize=True applies the transform's inverse from transform_state."""
     cfg = InferenceConfig(devices=["cpu"], output_denormalize=True)
     store = _FakeStore(np.float32)
 
-    # Normalized output 0.5 with state (mn, mx) = (10, 20) -> 0.5 * 10 + 10 = 15.
+    # An affine (Global) normalizer: inverse(v, (10, 20)) = v * 10 + 10.
+    # Normalized output 0.5 -> 0.5 * 10 + 10 = 15.
+    preprocess = GlobalNormalizer(10.0, 20.0, eps=cfg.eps)
     host_out = torch.full((1, 1, 2, 2, 2), 0.5, dtype=torch.float32)
     _run_writer_once(
-        cfg, store, _single_patch_preds(host_out, transform_state=(10.0, 20.0))
+        cfg,
+        store,
+        _single_patch_preds(host_out, transform_state=(10.0, 20.0)),
+        preprocess,
     )
 
     assert store.written is not None
@@ -205,13 +238,18 @@ def test_writer_applies_block_level_transform_state_inverse():
 
 
 def test_writer_ignores_transform_state_when_denorm_disabled():
-    """output_denormalize=False writes outputs as-is and never reads transform_state."""
+    """output_denormalize=False writes outputs as-is and never inverts."""
     cfg = InferenceConfig(devices=["cpu"], output_denormalize=False)
     store = _FakeStore(np.float32)
 
     host_out = torch.full((1, 1, 2, 2, 2), 0.5, dtype=torch.float32)
-    # transform_state=None proves the opaque blob is not inspected on this path.
-    _run_writer_once(cfg, store, _single_patch_preds(host_out, transform_state=None))
+    # An invertible transform is supplied, but output_denormalize=False skips it.
+    _run_writer_once(
+        cfg,
+        store,
+        _single_patch_preds(host_out, transform_state=(10.0, 20.0)),
+        GlobalNormalizer(10.0, 20.0, eps=cfg.eps),
+    )
 
     np.testing.assert_allclose(store.written, 0.5)
 

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -9,6 +9,7 @@ import torch
 
 from aind_torch_utils.accumulators import weighted_average_factory
 from aind_torch_utils.config import InferenceConfig
+from aind_torch_utils.outputs import OutputSpec, Threshold
 from aind_torch_utils.transforms import (
     GlobalNormalizer,
     IdentityTransform,
@@ -120,17 +121,26 @@ def _single_patch_preds(host_out, transform_state):
     )
 
 
+def _spec(cfg, store, postprocess=None, accumulator_factory=None):
+    """A single OutputSpec mirroring the run() default (invert=output_denormalize)."""
+    return OutputSpec(
+        store=store,
+        accumulator_factory=accumulator_factory or _default_factory(cfg),
+        postprocess=postprocess,
+        invert=cfg.output_denormalize,
+    )
+
+
 def _run_writer_once(cfg, store, preds, preprocess, full_shape=(2, 2, 2)):
     write_q: "queue.Queue[Optional[Preds]]" = queue.Queue()
     write_q.put(preds)
     write_q.put(None)  # sentinel closes the writer loop
     WriterWorker(
         cfg=cfg,
-        writers=[store],
+        outputs=[_spec(cfg, store)],
         write_q=write_q,
         preprocess=preprocess,
         full_shape=full_shape,
-        accumulator_factory=_default_factory(cfg),
     ).run(threading.Event())
 
 
@@ -199,11 +209,10 @@ def test_writer_raises_on_mismatched_output_channels_and_writers():
     # Single writer, but model output has N=2 channels.
     worker = WriterWorker(
         cfg=cfg,
-        writers=[object()],
+        outputs=[_spec(cfg, object())],
         write_q=write_q,
         preprocess=IdentityTransform(),
         full_shape=(2, 2, 2),
-        accumulator_factory=_default_factory(cfg),
     )
 
     preds = Preds(
@@ -262,6 +271,74 @@ def test_writer_ignores_transform_state_when_denorm_disabled():
     )
 
     np.testing.assert_allclose(store.written, 0.5)
+
+
+def test_writer_per_output_merge_post_and_dtype():
+    """Two outputs from one (B, 2, ...) tensor take different merge/post/dtype.
+
+    Channel 0: max-merge + threshold(0) + uint8 (a mask). Channel 1: weighted
+    average + no post + float32 (a raw field). A single block-sized patch means
+    merge is a no-op, isolating the per-output post/dtype/invert wiring.
+    """
+    from aind_torch_utils.accumulators import MaxAccumulator
+
+    cfg = InferenceConfig(devices=["cpu"], output_denormalize=False)
+    mask_store = _FakeStore(np.uint8)
+    field_store = _FakeStore(np.float32)
+
+    mask_spec = OutputSpec(
+        store=mask_store,
+        accumulator_factory=lambda shp, ctx: MaxAccumulator(shp),
+        postprocess=Threshold(thresh=0.0),
+        invert=False,
+    )
+    field_spec = OutputSpec(
+        store=field_store,
+        accumulator_factory=_default_factory(cfg),
+        postprocess=None,
+        invert=False,
+    )
+
+    # channel 0 = logits (mixed sign), channel 1 = a raw field.
+    logits = np.array([-2.0, 3.0, -1.0, 4.0, 0.5, -0.5, 9.0, -9.0], np.float32)
+    field = np.arange(8, dtype=np.float32)
+    host_out = torch.from_numpy(
+        np.stack([logits.reshape(2, 2, 2), field.reshape(2, 2, 2)])[None]
+    )  # (1, 2, 2, 2, 2)
+
+    preds = Preds(
+        block_idx=(0, 0, 0),
+        block_bbox=(slice(0, 2), slice(0, 2), slice(0, 2)),
+        linear_k=0,
+        starts_in_block=[(0, 0, 0)],
+        host_out=host_out,
+        valid_sizes=[(2, 2, 2)],
+        transform_state=None,
+        total_patches_in_block=1,
+        acc_shape=(2, 2, 2),
+        halo_left=(0, 0, 0),
+        ready_event=None,
+    )
+
+    write_q: "queue.Queue[Optional[Preds]]" = queue.Queue()
+    write_q.put(preds)
+    write_q.put(None)
+    WriterWorker(
+        cfg=cfg,
+        outputs=[mask_spec, field_spec],
+        write_q=write_q,
+        preprocess=IdentityTransform(),
+        full_shape=(2, 2, 2),
+    ).run(threading.Event())
+
+    # Mask: threshold(logit > 0) -> uint8 binary.
+    assert mask_store.written.dtype == np.uint8
+    np.testing.assert_array_equal(
+        mask_store.written.ravel(), (logits > 0).astype(np.uint8)
+    )
+    # Field: raw values as float32.
+    assert field_store.written.dtype == np.float32
+    np.testing.assert_allclose(field_store.written.ravel(), field)
 
 
 def _make_compile_worker():

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -9,6 +9,7 @@ import torch
 
 from aind_torch_utils.accumulators import weighted_average_factory
 from aind_torch_utils.config import InferenceConfig
+from aind_torch_utils.execution import ExecutionPolicy
 from aind_torch_utils.outputs import OutputSpec, Threshold
 from aind_torch_utils.transforms import (
     GlobalNormalizer,
@@ -22,6 +23,13 @@ def _default_preprocess(cfg):
     """The same transform run() synthesizes from config."""
     return from_config(
         cfg.normalize, cfg.norm_lower, cfg.norm_upper, cfg.eps, cfg.clip_norm
+    )
+
+
+def _default_execution(cfg):
+    """The same execution policy run() synthesizes from config."""
+    return ExecutionPolicy.from_config(
+        cfg.amp, cfg.use_compile, cfg.compile_mode, cfg.compile_dynamic
     )
 
 
@@ -152,7 +160,7 @@ def test_prep_worker_pads_tail_batch_to_constant_shape_when_compiling():
     cfg = _prep_cfg(use_compile=True)
     prep_q = queue.Queue()
     PrepWorker(
-        cfg, store, prep_q, cfg.patch, _default_preprocess(cfg)
+        cfg, store, prep_q, cfg.patch, _default_preprocess(cfg), _default_execution(cfg)
     ).run(threading.Event())
 
     batches = _drain(prep_q)
@@ -186,7 +194,7 @@ def test_prep_worker_does_not_pad_in_eager_mode():
     cfg = _prep_cfg(use_compile=False)
     prep_q = queue.Queue()
     PrepWorker(
-        cfg, store, prep_q, cfg.patch, _default_preprocess(cfg)
+        cfg, store, prep_q, cfg.patch, _default_preprocess(cfg), _default_execution(cfg)
     ).run(threading.Event())
 
     batches = _drain(prep_q)
@@ -200,6 +208,24 @@ def test_prep_worker_does_not_pad_in_eager_mode():
         if n_real < cfg.batch_size:
             saw_partial = True
     assert saw_partial, "geometry should produce a partial tail batch"
+
+
+def test_prep_worker_uses_execution_input_dtype():
+    """Host patch dtype comes from the ExecutionPolicy, not cfg.amp (decoupled)."""
+    store = _make_input_store((1, 1, 32, 32, 32))
+    cfg = _prep_cfg(use_compile=False)  # cfg.amp is False
+    prep_q = queue.Queue()
+    # Policy asks for float16 even though cfg.amp is False.
+    execution = ExecutionPolicy.from_config(
+        amp=True, use_compile=False, compile_mode="default", compile_dynamic=None
+    )
+    PrepWorker(
+        cfg, store, prep_q, cfg.patch, _default_preprocess(cfg), execution
+    ).run(threading.Event())
+
+    batches = _drain(prep_q)
+    assert batches
+    assert all(b.host_in.dtype == torch.float16 for b in batches)
 
 
 def test_writer_raises_on_mismatched_output_channels_and_writers():
@@ -345,9 +371,11 @@ def _make_compile_worker():
     """Build a GpuWorker shell without running __init__ (which needs CUDA),
     wired with just the attributes _compile_model touches."""
     worker = object.__new__(GpuWorker)
-    worker.cfg = InferenceConfig(devices=["cpu"], use_compile=True)
+    cfg = InferenceConfig(devices=["cpu"], use_compile=True)
+    worker.cfg = cfg
     worker.device = torch.device("cpu")
     worker.model = torch.nn.Identity()
+    worker.execution = _default_execution(cfg)
     return worker
 
 

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -7,6 +7,7 @@ import pytest
 import tensorstore as ts
 import torch
 
+from aind_torch_utils.accumulators import weighted_average_factory
 from aind_torch_utils.config import InferenceConfig
 from aind_torch_utils.transforms import (
     GlobalNormalizer,
@@ -20,6 +21,13 @@ def _default_preprocess(cfg):
     """The same transform run() synthesizes from config."""
     return from_config(
         cfg.normalize, cfg.norm_lower, cfg.norm_upper, cfg.eps, cfg.clip_norm
+    )
+
+
+def _default_factory(cfg):
+    """The same accumulator factory run() synthesizes from config."""
+    return weighted_average_factory(
+        cfg.eps, cfg.overlap, cfg.seam_mode, cfg.trim_voxels, cfg.min_blend_weight
     )
 
 
@@ -122,6 +130,7 @@ def _run_writer_once(cfg, store, preds, preprocess, full_shape=(2, 2, 2)):
         write_q=write_q,
         preprocess=preprocess,
         full_shape=full_shape,
+        accumulator_factory=_default_factory(cfg),
     ).run(threading.Event())
 
 
@@ -194,6 +203,7 @@ def test_writer_raises_on_mismatched_output_channels_and_writers():
         write_q=write_q,
         preprocess=IdentityTransform(),
         full_shape=(2, 2, 2),
+        accumulator_factory=_default_factory(cfg),
     )
 
     preds = Preds(

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -9,6 +9,7 @@ import torch
 
 from aind_torch_utils.accumulators import weighted_average_factory
 from aind_torch_utils.config import InferenceConfig
+from aind_torch_utils.context import BlockContext
 from aind_torch_utils.execution import ExecutionPolicy
 from aind_torch_utils.outputs import OutputSpec, Threshold
 from aind_torch_utils.transforms import (
@@ -112,6 +113,19 @@ class _FakeStore:
         return _FakeSlice(self)
 
 
+def _block_ctx(extent=2, full_shape=(2, 2, 2)):
+    """A no-halo BlockContext for a block spanning [0, extent) on each axis."""
+    bbox = (slice(0, extent),) * 3
+    return BlockContext.from_block(
+        block_idx=(0, 0, 0),
+        core_bbox=bbox,
+        expanded_bbox=bbox,
+        full_shape=full_shape,
+        t_idx=0,
+        c_idx=0,
+    )
+
+
 def _single_patch_preds(host_out, transform_state):
     """A Preds for a 2x2x2 single-patch block that completes on arrival."""
     return Preds(
@@ -125,6 +139,7 @@ def _single_patch_preds(host_out, transform_state):
         total_patches_in_block=1,
         acc_shape=(2, 2, 2),
         halo_left=(0, 0, 0),
+        ctx=_block_ctx(),
         ready_event=None,
     )
 
@@ -139,7 +154,7 @@ def _spec(cfg, store, postprocess=None, accumulator_factory=None):
     )
 
 
-def _run_writer_once(cfg, store, preds, preprocess, full_shape=(2, 2, 2)):
+def _run_writer_once(cfg, store, preds, preprocess):
     write_q: "queue.Queue[Optional[Preds]]" = queue.Queue()
     write_q.put(preds)
     write_q.put(None)  # sentinel closes the writer loop
@@ -148,7 +163,6 @@ def _run_writer_once(cfg, store, preds, preprocess, full_shape=(2, 2, 2)):
         outputs=[_spec(cfg, store)],
         write_q=write_q,
         preprocess=preprocess,
-        full_shape=full_shape,
     ).run(threading.Event())
 
 
@@ -238,7 +252,6 @@ def test_writer_raises_on_mismatched_output_channels_and_writers():
         outputs=[_spec(cfg, object())],
         write_q=write_q,
         preprocess=IdentityTransform(),
-        full_shape=(2, 2, 2),
     )
 
     preds = Preds(
@@ -252,6 +265,7 @@ def test_writer_raises_on_mismatched_output_channels_and_writers():
         total_patches_in_block=1,
         acc_shape=(2, 2, 2),
         halo_left=(0, 0, 0),
+        ctx=_block_ctx(),
         ready_event=None,
     )
 
@@ -343,6 +357,7 @@ def test_writer_per_output_merge_post_and_dtype():
         total_patches_in_block=1,
         acc_shape=(2, 2, 2),
         halo_left=(0, 0, 0),
+        ctx=_block_ctx(),
         ready_event=None,
     )
 
@@ -354,7 +369,6 @@ def test_writer_per_output_merge_post_and_dtype():
         outputs=[mask_spec, field_spec],
         write_q=write_q,
         preprocess=IdentityTransform(),
-        full_shape=(2, 2, 2),
     ).run(threading.Event())
 
     # Mask: threshold(logit > 0) -> uint8 binary.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,110 @@
+"""Tests for Workflow, WorkflowRegistry, and run_workflow unpacking."""
+import pytest
+
+import aind_torch_utils.run as run_mod
+from aind_torch_utils.execution import ExecutionPolicy
+from aind_torch_utils.outputs import OutputSpec
+from aind_torch_utils.workflow import Workflow, WorkflowRegistry
+
+
+def _factory():
+    return object()
+
+
+def test_workflow_defaults():
+    wf = Workflow(processor=object())
+    assert wf.preprocess is None
+    assert wf.outputs is None
+    assert isinstance(wf.execution, ExecutionPolicy)
+    assert wf.resolve_outputs([object()]) is None
+
+
+def test_workflow_resolve_fixed_outputs():
+    specs = [OutputSpec(store=object(), accumulator_factory=_factory())]
+    wf = Workflow(processor=object(), outputs=specs)
+    assert wf.resolve_outputs([object(), object()]) is specs
+
+
+def test_workflow_resolve_via_factory():
+    stores = [object(), object()]
+    seen = {}
+
+    def make_specs(s):
+        seen["stores"] = s
+        return [OutputSpec(store=st, accumulator_factory=_factory()) for st in s]
+
+    wf = Workflow(processor=object(), output_spec_factory=make_specs)
+    specs = wf.resolve_outputs(stores)
+    assert seen["stores"] is stores
+    assert len(specs) == 2
+
+
+def test_workflow_rejects_outputs_and_factory():
+    with pytest.raises(ValueError, match="not both"):
+        Workflow(
+            processor=object(),
+            outputs=[OutputSpec(store=object(), accumulator_factory=_factory())],
+            output_spec_factory=lambda s: [],
+        )
+
+
+def test_registry_register_build_list():
+    @WorkflowRegistry.register("unit-test-workflow")
+    def _build(params):
+        return Workflow(
+            processor=object(),
+            execution=ExecutionPolicy(compile=params.get("c", False)),
+        )
+
+    assert "unit-test-workflow" in WorkflowRegistry.list_workflows()
+    wf = WorkflowRegistry.build("unit-test-workflow", {"c": True})
+    assert wf.execution.compile is True
+    # missing params -> empty dict
+    assert WorkflowRegistry.build("unit-test-workflow").execution.compile is False
+
+
+def test_registry_unknown_raises():
+    with pytest.raises(KeyError, match="not found in registry"):
+        WorkflowRegistry.build("does-not-exist")
+
+
+def test_run_workflow_forwards_processor_and_defaults(monkeypatch):
+    captured = {}
+
+    def fake_run(model, input_store, output_store, cfg, **kw):
+        captured["model"] = model
+        captured["output_store"] = output_store
+        captured.update(kw)
+
+    monkeypatch.setattr(run_mod, "run", fake_run)
+
+    proc, pp = object(), object()
+    exec_policy = ExecutionPolicy(autocast=True)
+    wf = Workflow(processor=proc, preprocess=pp, execution=exec_policy)
+    run_mod.run_workflow(wf, "IN", "OUT", "CFG", metrics_json="m.json")
+
+    assert captured["model"] is proc
+    assert captured["preprocess"] is pp
+    assert captured["execution"] is exec_policy
+    assert captured["outputs"] is None
+    # No explicit outputs -> the store is forwarded for run() to synthesize specs.
+    assert captured["output_store"] == "OUT"
+    assert captured["metrics_json"] == "m.json"
+
+
+def test_run_workflow_with_fixed_outputs_passes_none_store(monkeypatch):
+    captured = {}
+
+    def fake_run(model, input_store, output_store, cfg, **kw):
+        captured["output_store"] = output_store
+        captured["outputs"] = kw["outputs"]
+
+    monkeypatch.setattr(run_mod, "run", fake_run)
+
+    specs = [OutputSpec(store=object(), accumulator_factory=_factory())]
+    wf = Workflow(processor=object(), outputs=specs)
+    run_mod.run_workflow(wf, "IN", "OUT", "CFG")
+
+    # Explicit specs -> output_store must be None (run rejects both).
+    assert captured["output_store"] is None
+    assert captured["outputs"] is specs

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -15,7 +15,10 @@ def test_workflow_defaults():
     wf = Workflow(processor=object())
     assert wf.preprocess is None
     assert wf.outputs is None
-    assert isinstance(wf.execution, ExecutionPolicy)
+    # None means "synthesize from config" — the same rule as preprocess — so
+    # CLI/config AMP and compile flags stay live for recipes that don't pin
+    # their own policy.
+    assert wf.execution is None
     assert wf.resolve_outputs([object()]) is None
 
 
@@ -108,3 +111,24 @@ def test_run_workflow_with_fixed_outputs_passes_none_store(monkeypatch):
     # Explicit specs -> output_store must be None (run rejects both).
     assert captured["output_store"] is None
     assert captured["outputs"] is specs
+
+
+def test_run_workflow_default_execution_falls_back_to_config(monkeypatch):
+    """A recipe that leaves execution unset forwards None so run() synthesizes
+    the policy from cfg — CLI/config AMP and compile flags stay live."""
+    captured = {}
+
+    def fake_run(model, input_store, output_store, cfg, **kw):
+        captured.update(kw)
+
+    monkeypatch.setattr(run_mod, "run", fake_run)
+
+    run_mod.run_workflow(Workflow(processor=object()), "IN", "OUT", "CFG")
+    assert captured["execution"] is None
+
+
+def test_run_workflow_factory_requires_output_store():
+    """A factory-based workflow must get real stores, not a wrapped [None]."""
+    wf = Workflow(processor=object(), output_spec_factory=lambda stores: [])
+    with pytest.raises(ValueError, match="provide output_store"):
+        run_mod.run_workflow(wf, "IN", None, "CFG")


### PR DESCRIPTION
# Refactor the tiled inference pipeline into a composable workflow runtime

## Summary

This PR turns the existing queue-based denoising runner into a generic tiled-volume runtime. The threading, TensorStore I/O, block/patch geometry, multi-GPU scheduling, monitoring, and shutdown behavior remain in the core pipeline; workflow-specific math is moved behind small injectable contracts.

The new extension points cover:

- block-scoped input preprocessing and optional inversion;
- tensor-in/tensor-out processing and its execution policy;
- per-output patch accumulation, postprocessing, inversion, and destination store;
- named workflows that package those decisions for programmatic or CLI use.

Existing callers do not have to adopt the new objects immediately. When an extension point is omitted, `run()` synthesizes the legacy normalization, execution, and trim/blend output behavior from `InferenceConfig`.

## Motivation

The previous implementation embedded one workflow's assumptions directly in the workers:

- preparation chose a normalization mode and exposed its `(min, max)` representation;
- the GPU stage assumed the processor was an `nn.Module` and read AMP/compile behavior from global config;
- every output used the same continuous-valued trim/blend accumulator;
- the writer always followed the same denormalization and casting path.

Those assumptions work for intensity-preserving denoising, but not for workflows such as masking and segmentation. A binary mask should not be averaged across overlapping patches, a label output should not be treated like an intensity image, and a probability or mask output should not be inverse-normalized. Likewise, calibration corrections need absolute block coordinates and non-neural processors may need eager float32 execution regardless of the CLI defaults.

This refactor keeps the optimized pipeline reusable while allowing each workflow to declare the math that gives its outputs meaning.

## Architecture overview

```text
InferenceConfig                         Workflow
(geometry, devices, queues)             (workflow-owned math)
         |                                      |
         +------------------+-------------------+
                            v
Input TensorStore -> PrepWorker -> Batch -> GpuWorker -> Preds -> WriterWorker
                       |          |            |             |
                       |          |            |             +-> one OutputSpec
                       |          |            |                 per output channel
                       |          |            |
                       |          |            +-> ExecutionPolicy
                       |          |
                       |          +-> BlockContext + opaque transform_state
                       |
                       +-> BlockPreprocessor.forward(block, context)

Writer finalization per output:
accumulate patches -> finalize expanded block -> optional inverse -> postprocess
                   -> crop halo -> cast to destination dtype -> TensorStore write
```

The important separation is that `InferenceConfig` still describes how the runtime moves through a volume, while `Workflow` describes what computation is being run and what each output means.

## Main components

### `BlockContext` and runtime carriers

`context.py` adds an immutable `BlockContext` containing the block index, absolute core and expanded bounding boxes, actual left halo, full spatial shape, and time/channel indices.

The prep stage creates this context once per block. `Batch` and `Preds` carry it unchanged through the GPU stage to the writer, alongside an opaque per-block `transform_state`. The runtime never interprets that state; only the matching preprocessor/inverse owns its schema.

Absolute `expanded_bbox` coordinates are especially important for corrections that sample a global field. Two halo-overlapping blocks can sample the same field at the same absolute voxels and therefore produce identical corrected values at their seam.

### Block preprocessing and inversion

`transforms.py` defines the `BlockPreprocessor` contract:

```python
forward(block, context) -> (transformed_block, opaque_state)
```

Invertible transforms also provide:

```python
inverse(block, opaque_state, context) -> restored_block
```

An invertible transform declares whether inversion must happen once after block finalization or on every patch before accumulation. The default and fastest path is `after_finalize`, which is correct for affine normalization because inverse normalization commutes with averaging.

The branch includes:

- `PercentileNormalizer`, preserving the existing per-block percentile behavior;
- `GlobalNormalizer`, preserving fixed-range clipping and scaling;
- `IdentityTransform` for disabled normalization;
- one-way `Clip`;
- `Sequential`, which composes preprocessors left-to-right and applies the invertible members in reverse.

`transforms.from_config()` is the compatibility adapter used when callers do not inject a preprocessor.

### Processor execution policy

`execution.py` introduces `ExecutionPolicy`, which moves processor-specific execution requirements out of global runtime logic:

- input dtype;
- autocast;
- inference mode;
- `torch.compile` enablement, mode, and dynamic-shape setting;
- channels-last memory format.

`GpuWorker` applies module-only operations such as `.to()` and `.eval()` only to `nn.Module` instances. Plain tensor-in/tensor-out callables are supported without deep-copying them or assuming that they expose neural-network APIs.

The policy also protects directly injected workflows from CUDA-graph compile modes that are unsafe in the threaded worker model, and compiled runs retain constant tail batch shapes through padding.

When no policy is supplied, `ExecutionPolicy.from_config()` reproduces the previous AMP and compile behavior.

### Pluggable block accumulation

`accumulators.py` extracts patch merging behind `BlockAccumulator` and `BlockAccumulatorFactory`. A fresh accumulator is created for every block and every output channel.

Provided strategies are:

- `WeightedAverageAccumulator` for the legacy trim/blend behavior on continuous outputs;
- `LastWriteAccumulator` for disjoint patches or deterministic overwrite semantics;
- `MaxAccumulator` for masks/logits where any positive patch should win;
- `SumAccumulator` for counts or densities;
- `MajorityVoteAccumulator` for discrete values where averaging is meaningless.

The writer, rather than the accumulator, tracks how many patches have arrived. This keeps completion bookkeeping out of custom accumulator implementations.

### Per-output finalization

`outputs.py` adds `OutputSpec`. Each model output channel independently selects:

- its destination TensorStore;
- its accumulator factory;
- an optional block postprocessor;
- whether the shared input transform should be inverted for that output.

This allows one processor to emit, for example, a continuous intensity channel and a binary mask channel without forcing them through the same merge or inverse path.

Postprocessors run on the finalized expanded block before halo cropping, so local neighborhood operations can use halo context. `Threshold` and `ThresholdThenOpen` are included as basic implementations. The destination store controls the final dtype; integer writes are clipped to the destination range before casting.

The writer validates the model's `(B, N, Z, Y, X)` output shape against the number of `OutputSpec`s and fails clearly on a mismatch. The legacy single-output `(B, Z, Y, X)` form remains accepted.

### Workflow composition and registry

`workflow.py` groups the processor, preprocessor, output definitions, and execution policy into one `Workflow`. Outputs may be fixed `OutputSpec`s or built after the CLI opens its destination stores through an `output_spec_factory`.

`WorkflowRegistry` maps a stable name to a builder that accepts a plain parameter dictionary. `run_workflow()` resolves the workflow and delegates to the same `run()` implementation used by legacy model invocations.

The CLI now accepts exactly one of:

- `--model-type`, retaining the existing model-registry path; or
- `--workflow`, with optional JSON `--workflow-params`.

Output arguments are validated before opening stores, which avoids creating or truncating an output that a fixed-output workflow would ignore. `--weights` is rejected with `--workflow`; workflow-owned weights belong in `--workflow-params`.

`recipes/` is the registration point for concrete workflows. This PR intentionally establishes the contracts first and leaves the package empty until a real specialized workflow is ported.

### Runtime safety and lifecycle

The existing prep/GPU/writer pipeline and block-to-writer sharding remain intact. Worker entry points are now guarded so an uncaught exception records the failing thread, sets the shared stop event, unblocks peer workers, and is re-raised from `run()`. A failed worker can no longer look like a successful run with empty output or leave the pipeline waiting forever on full queues.

Inversion configuration and output destinations are also validated before threads start, keeping configuration errors in the caller's thread.

## End-to-end runtime flow

1. `run_workflow()` resolves fixed outputs or calls the workflow's output factory.
2. `run()` fills any omitted extension points from `InferenceConfig` and validates the output/inversion combination.
3. Each `PrepWorker` reads an expanded core-plus-halo block, creates its `BlockContext`, and calls `preprocess.forward()` once for the full block.
4. The transformed block is tiled into overlapping patches. The context and opaque transform state travel on every `Batch` for that block.
5. `GpuWorker` transfers a batch to its assigned device and invokes the processor under the workflow's `ExecutionPolicy`.
6. Predictions are routed by block to one writer, ensuring all patches for a block are accumulated by the same thread.
7. The writer creates one accumulator per output, merges every valid patch, and waits until the block is complete.
8. Each output is finalized independently: inverse if requested, postprocess, crop the halo back to the core bounding box, cast, and write.
9. Queue/system metrics and throughput are reported as before; worker failures are propagated after cooperative shutdown.

## Backward compatibility

The public `run(model, input_store, output_store, cfg, ...)` path remains valid. Its new arguments are optional:

- `preprocess=None` builds the prior normalization/clip behavior from config;
- `outputs=None` builds one legacy weighted trim/blend `OutputSpec` per output store and uses `cfg.output_denormalize` for inversion;
- `execution=None` builds the prior AMP/compile behavior from config.

This makes adoption incremental: existing workflows keep their current behavior while new workflows can replace one policy at a time or package all policies in a `Workflow`.

## Example: mapping `feat-test-hysteresis` onto this architecture

`feat-test-hysteresis` is a strong first consumer because it combines a global flat-field correction, fixed-range normalization, a CuPy masking processor, a two-level hysteresis seed mask, topology-aware connected-components passes, optional instance labeling, and OME-Zarr pyramid generation.

The streaming segmentation portion maps directly to the new contracts:

| `feat-test-hysteresis` concern | Refactored home |
| --- | --- |
| `flatfield*` fields added to `InferenceConfig` | Workflow parameters used to construct a context-aware block preprocessor |
| `background=` threaded through `run()` and `PrepWorker` | A `FlatFieldCorrection.forward()` implementation using `BlockContext.expanded_bbox` |
| Inline percentile/global normalization and `per_block_minmax` | `PercentileNormalizer` or `GlobalNormalizer`; any inverse state remains opaque |
| `GfpMaskModel` / CuPy masking function | `Workflow.processor` |
| `amp=False`, `use_compile=False`, float32 input | Workflow-owned `ExecutionPolicy` |
| `output_denormalize=False` | `OutputSpec(invert=False)` |
| Trim/blend merging of `{0,1,2}` patches | `MaxAccumulator`, preserving seed > grow > background without averaging |
| `uint8` seed-mask output | Destination store plus its `OutputSpec` |
| Worker exception wrappers | Already provided by the refactored runtime; do not port the duplicate core changes |
| Hysteresis CCL, hole filling, and instance stitching | Dataset-level orchestration after the streaming workflow finishes |
| Pyramid construction, OME metadata, resume, and blank checks | Application/example orchestration around `run_workflow()` |

The following illustrates a named recipe after the feature branch's `correction.py` and `postprocessing.py` domain code is ported. For CLI use, the coarse background is precomputed once and stored in an `.npz` containing `field` and `scale`; a programmatic runner could construct the same `BackgroundField` in memory.

```python
import numpy as np
import torch

from aind_torch_utils.accumulators import MaxAccumulator
from aind_torch_utils.correction import (
    BackgroundField,
    apply_flatfield,
    sample_background,
)
from aind_torch_utils.execution import ExecutionPolicy
from aind_torch_utils.outputs import OutputSpec
from aind_torch_utils.postprocessing import GfpMaskModel
from aind_torch_utils.transforms import GlobalNormalizer, Sequential
from aind_torch_utils.workflow import Workflow, WorkflowRegistry

class FlatFieldCorrection:
    """One-way correction sampled in absolute volume coordinates."""

    def __init__(self, background, mode="subtract", eps=1e-6):
        self.background = background
        self.mode = mode
        self.eps = eps

    def forward(self, block, ctx):
        z, y, x = ctx.expanded_bbox
        background = sample_background(
            self.background.field,
            self.background.scale,
            z.start,
            z.stop,
            y.start,
            y.stop,
            x.start,
            x.stop,
        )
        corrected = apply_flatfield(
            block,
            background,
            mode=self.mode,
            eps=self.eps,
            bg_mean=self.background.mean,
        )
        return corrected, None

def max_factory(shape, ctx):
    return MaxAccumulator(shape)

@WorkflowRegistry.register("gfp-hysteresis")
def build_gfp_hysteresis(params):
    with np.load(params["background_npz"]) as data:
        background = BackgroundField(
            field=data["field"].copy(),
            scale=tuple(float(v) for v in data["scale"]),
        )

    sigma = params.get("smooth_sigma", [0.5, 1.0, 1.0])
    sigma = None if sigma is None else tuple(sigma)

    processor = GfpMaskModel(
        threshold=params["threshold"],
        seed_threshold=params["seed_threshold"],
        smooth_sigma=sigma,
        open_iterations=params.get("open_iterations", 1),
    )

    preprocess = Sequential(
        [
            FlatFieldCorrection(
                background,
                mode=params.get("flatfield_mode", "subtract"),
            ),
            GlobalNormalizer(
                params["norm_lower"],
                params["norm_upper"],
            ),
        ]
    )

    def build_outputs(stores):
        if len(stores) != 1:
            raise ValueError("gfp-hysteresis expects one uint8 output store")
        return [
            OutputSpec(
                store=stores[0],
                accumulator_factory=max_factory,
                postprocess=None,
                invert=False,
            )
        ]

    return Workflow(
        processor=processor,
        preprocess=preprocess,
        output_spec_factory=build_outputs,
        execution=ExecutionPolicy(
            input_dtype=torch.float32,
            autocast=False,
            inference_mode=True,
            compile=False,
        ),
    )
```

The streaming stage can then be selected through the generic CLI:

```bash
python -m aind_torch_utils.run \
  --workflow gfp-hysteresis \
  --workflow-params gfp-hysteresis.json \
  --in-spec input-level.json \
  --out-spec seed-mask-level.json \
  --patch 64 64 64 \
  --block 256 256 256 \
  --overlap 10 \
  --devices cuda:0
```

That invocation writes the intermediate `{0,1,2}` seed/grow mask. The feature runner then continues with the existing dataset-level stages:

1. `_hysteresis_connect()` labels grow regions, stitches labels across block faces, and keeps only components containing a seed.
2. `_fill_holes_connect()` optionally performs seam-correct background connectivity.
3. `_instance_connect()` optionally assigns globally consistent `uint32` IDs.
4. The binary or label-aware pyramid builder writes coarser/finer levels and OME-NGFF metadata.

These operations intentionally remain outside `BlockPostProcessor`: they require cross-block equivalence classes, multiple full-dataset passes, and output-store lifecycle decisions. A block postprocessor only has one finalized expanded block and cannot make those global topology decisions correctly. Instance IDs also remain exact by being generated post hoc into `uint32`, rather than passing through the runtime's float prediction buffers.

### Suggested branch integration sequence

`feat-test-hysteresis` diverged before the current `dev` and directly edits `config.py`, `run.py`, and `workers.py`, so merging those core files verbatim would reintroduce the coupling this PR removes. A lower-risk integration is:

1. Start the migration from `refactor-architecture`.
2. Port the feature branch's domain modules and tests (`correction.py`, `postprocessing.py`, `labeling.py`, and optional dependencies).
3. Keep the refactored `run.py` and `workers.py`; replace the feature branch's `background` plumbing and flat-field worker branches with a preprocessor.
4. Move masking/normalization/correction parameters into a registered recipe's parameter dictionary. Keep only geometry, device, queue, and I/O scheduling values in `InferenceConfig`.
5. Replace `run(model, ..., background=...)` in the example with a constructed `Workflow` plus `run_workflow()`.
6. Retain the post-hoc CCL, hole-fill, instance-label, pyramid, metadata, resume, and blank-output orchestration around that streaming call.
7. Add parity tests for the seed-mask stage and end-to-end tests that compare the existing and migrated hysteresis/fill/instance outputs on a small volume crossing both patch and block boundaries.

This lets the feature branch keep its specialized behavior without growing another set of workflow-specific branches inside the generic workers.

## Scope and known boundaries

- `BlockPostProcessor` is block-local. Global connected-components, cross-block label stitching, pyramids, resumability, and metadata remain orchestration concerns.
- `before_accumulate` inversion currently receives block context but no per-patch absolute offset. It is suitable for spatially uniform nonlinear inverses; spatially varying coordinate-dependent inverses should use `after_finalize` or extend the carrier contract in a follow-up.
- Prediction and accumulator buffers are float16/float32. Large integer instance IDs should be created after the streaming mask stage (as the hysteresis branch already does) or require a future integer-preserving carrier path.
- The workflow registry is intentionally small and provisional until multiple concrete recipes have exercised the contracts.

## Testing

The branch adds focused coverage for contexts, transforms, execution policies, accumulators, output specs, workflow resolution/registration, CLI validation, worker carriers, per-output writer behavior, callable processors, inversion validation, and failure propagation.

```text
python -m pytest -q tests --import-mode=importlib
75 passed
```

I ran both the proteomics example and denoising examples to verify the results are byte-equivalent before and after the changes as well as throughput.

Test machine: g6e.xlarge -- 4cpus/32GB RAM, 1 Nvidia L40S GPU

Proteomics test script:
```bash
#!/usr/bin/env bash

: "${AWS_MAX_ATTEMPTS:=100}"
: "${OMP_NUM_THREADS:=1}"
: "${MKL_NUM_THREADS:=1}"
: "${OPENBLAS_NUM_THREADS:=1}"
: "${NUMEXPR_NUM_THREADS:=1}"
: "${TENSORSTORE_HTTP_THREADS:=16}"
: "${TENSORSTORE_HTTP2_MAX_CONCURRENT_STREAMS:=16}"
: "${TENSORSTORE_S3_REQUEST_CONCURRENCY:=64}"

export AWS_REGION=us-west-2
export AWS_RETRY_MODE=standard
export AWS_MAX_ATTEMPTS

export OMP_NUM_THREADS
export MKL_NUM_THREADS
export OPENBLAS_NUM_THREADS
export NUMEXPR_NUM_THREADS

export TENSORSTORE_HTTP_THREADS
export TENSORSTORE_HTTP2_MAX_CONCURRENT_STREAMS
export TENSORSTORE_S3_REQUEST_CONCURRENCY

python examples/run_proteomics_example.py \
    --in-spec /root/capsule/scratch/panluminate_tile_test_spec.json \
    --out-bucket aind-scratch-data \
    --out-prefix cameron.arshadi/predictions/panluminate_tile_test_latest \
    --encoder-weights /root/capsule/scratch/proteomics_all_data_global_percentiles_encoder.ckpt \
    --decoder-weights /root/capsule/scratch/bassoon_gbl_percentile_norm_638panluminate.ckpt \
    --output-names bassoon \
    --prep-workers 2 \
    --writer-workers 2 \
    --batch 16 \
    --block 337 960 960 \
    --percentiles-dir /root/capsule/scratch/percentiles
```
Inference time:
```
2026-07-15 15:18:50,828 - aind_torch_utils.run - INFO - Total time: 85.58s
2026-07-15 15:18:50,828 - aind_torch_utils.run - INFO - Throughput: 29.03MB/s
```
Inference results on current dev branch and this PR branch: [neuroglancer link](https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B1.0001949813743551e-7%2C%22m%22%5D%2C%22y%22:%5B1.0001949813743551e-7%2C%22m%22%5D%2C%22z%22:%5B3.9999999999999993e-7%2C%22m%22%5D%2C%22t%22:%5B0.001%2C%22s%22%5D%7D%2C%22position%22:%5B743.8566284179688%2C1127.804931640625%2C132.6534881591797%2C0%5D%2C%22crossSectionScale%22:4.481689070338066%2C%22projectionScale%22:65536%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22s3://aind-open-data/HCR_000000-s107-ls1_2026-01-23_00-00-00/SPIM/Tile_X_0001_Y_0008_Z_0000_ch_488.ome.zarr/%7Czarr3:%22%2C%22localDimensions%22:%7B%22c%27%22:%5B1%2C%22%22%5D%7D%2C%22localPosition%22:%5B0%5D%2C%22tab%22:%22rendering%22%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B456%2C3484%5D%2C%22window%22:%5B0%2C4247%5D%7D%7D%2C%22name%22:%22channel_488.zarr%22%7D%2C%7B%22type%22:%22image%22%2C%22source%22:%22s3://aind-scratch-data/cameron.arshadi/predictions/panluminate_tile_test_latest/bassoon.zarr/%7Czarr2:%22%2C%22localDimensions%22:%7B%22c%27%22:%5B1%2C%22%22%5D%7D%2C%22localPosition%22:%5B0%5D%2C%22tab%22:%22rendering%22%2C%22opacity%22:1%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B0.009638207415079907%2C0.9918145190621503%5D%2C%22window%22:%5B-0.23783928843300084%2C1.239292014910231%5D%7D%7D%2C%22name%22:%22bassoon.zarr%22%7D%2C%7B%22type%22:%22image%22%2C%22source%22:%22s3://aind-scratch-data/cameron.arshadi/predictions/panluminate_tile_test_latest_dev_branch/bassoon.zarr/%7Czarr2:%22%2C%22localDimensions%22:%7B%22c%27%22:%5B1%2C%22%22%5D%7D%2C%22localPosition%22:%5B0%5D%2C%22tab%22:%22rendering%22%2C%22opacity%22:1%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B0.009638207415079907%2C0.9918145190621503%5D%2C%22window%22:%5B-0.23783928843300084%2C1.239292014910231%5D%7D%7D%2C%22name%22:%22bassoon.zarr1%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22bassoon.zarr1%22%7D%2C%22layout%22:%224panel-alt%22%7D)

Denoise test script:
```bash
#!/usr/bin/env bash

: "${AWS_MAX_ATTEMPTS:=10}"
: "${OMP_NUM_THREADS:=1}"
: "${MKL_NUM_THREADS:=1}"
: "${OPENBLAS_NUM_THREADS:=1}"
: "${NUMEXPR_NUM_THREADS:=1}"
: "${TENSORSTORE_HTTP_THREADS:=32}"
: "${TENSORSTORE_HTTP2_MAX_CONCURRENT_STREAMS:=32}"
: "${TENSORSTORE_S3_REQUEST_CONCURRENCY:=64}"

export AWS_REGION=us-west-2
export AWS_RETRY_MODE=standard
export AWS_MAX_ATTEMPTS

export OMP_NUM_THREADS
export MKL_NUM_THREADS
export OPENBLAS_NUM_THREADS
export NUMEXPR_NUM_THREADS

export TENSORSTORE_HTTP_THREADS
export TENSORSTORE_HTTP2_MAX_CONCURRENT_STREAMS
export TENSORSTORE_S3_REQUEST_CONCURRENCY

python -m aind_torch_utils.run \
  --in-spec /root/capsule/scratch/specs/in_spec.json \
  --out-spec /root/capsule/scratch/specs/out_spec.json \
  --model-type denoise-net \
  --weights /root/capsule/scratch/BM4DNet-20250905-169-0.0073.pth \
  --t 0 --c 0 \
  --patch 64 64 64 \
  --overlap 10 \
  --block 256 256 256 \
  --batch 32 \
  --devices cuda:0 \
  --seam-mode blend \
  --halo 5 \
  --max-inflight-batches 32 \
  --norm-lower 0.5 --norm-upper 99.9 \
  --clip-norm 0.0 5.0 \
  --prep-workers 2 \
  --writer-workers 2 \
  --metrics-json /results/metrics.json \
  --metrics-interval 1 
```
Inference time:
```
2026-07-15 15:12:12,929 - __main__ - INFO - Total time: 171.93s
2026-07-15 15:12:12,929 - __main__ - INFO - Throughput: 56.21MB/s
```
Inference result: [neuroglancer link](https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22d2%22:%5B1%2C%22%22%5D%2C%22d3%22:%5B1%2C%22%22%5D%2C%22d4%22:%5B1%2C%22%22%5D%2C%22d0%22:%5B1%2C%22%22%5D%2C%22d1%22:%5B1%2C%22%22%5D%7D%2C%22position%22:%5B849.2269897460938%2C729.6943969726562%2C1070.5%2C0.5%2C0.5%5D%2C%22crossSectionScale%22:2.718281828459046%2C%22projectionScale%22:2048%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%7B%22url%22:%22s3://aind-scratch-data/cameron.arshadi/test-tile-level3.zarr/0/%7Czarr2:%22%2C%22subsources%22:%7B%22default%22:true%2C%22bounds%22:true%7D%2C%22enableDefaultSubsources%22:false%7D%2C%22tab%22:%22rendering%22%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B43%2C50%5D%2C%22window%22:%5B41%2C52%5D%7D%7D%2C%22name%22:%220%22%7D%2C%7B%22type%22:%22image%22%2C%22source%22:%22s3://aind-scratch-data/cameron.arshadi/test-tile-level3-dev-branch.zarr/0/%7Czarr2:%22%2C%22tab%22:%22rendering%22%2C%22opacity%22:1%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B43%2C50%5D%2C%22window%22:%5B41%2C52%5D%7D%7D%2C%22name%22:%2201%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%2201%22%7D%2C%22layout%22:%224panel-alt%22%7D)
